### PR TITLE
[fix] Nested messages with a package should build.

### DIFF
--- a/proto/message.py
+++ b/proto/message.py
@@ -220,7 +220,7 @@ class MessageMeta(type):
         if len(local_path) == 1:
             file_info.descriptor.message_type.add().MergeFrom(desc)
         else:
-            file_info.nested[tuple(full_name.split('.'))] = desc
+            file_info.nested[local_path] = desc
 
         # Create the MessageInfo instance to be attached to this message.
         attrs['_meta'] = _MessageInfo(

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with io.open(os.path.join(PACKAGE_ROOT, 'README.rst')) as file_obj:
 
 setup(
     name='proto-plus',
-    version='0.2.0',
+    version='0.2.1',
     license='Apache 2.0',
     author='Luke Sneeringer',
     author_email='lukesneeringer@google.com',


### PR DESCRIPTION
This fixes a bug where nested messages that had package names would not build properly, because the outer message would never register as being ready.