### PR TITLE
[refactor] Add module-level `__protobuf__` value.

### DIFF
--- a/proto/__init__.py
+++ b/proto/__init__.py
@@ -17,6 +17,7 @@ from .fields import MapField
 from .fields import RepeatedField
 from .marshal import Marshal
 from .message import Message
+from .modules import define_module as module
 from .primitives import ProtoType
 
 
@@ -45,6 +46,7 @@ __all__ = (
     'RepeatedField',
     'Marshal',
     'Message',
+    'module',
 
     # Expose the types directly.
     'DOUBLE',

--- a/proto/modules.py
+++ b/proto/modules.py
@@ -1,0 +1,50 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Set
+import collections
+
+
+_ProtoModule = collections.namedtuple('ProtoModule',
+    ['package', 'marshal', 'manifest'],
+)
+
+
+def define_module(*, package: str, marshal: str = None,
+            manifest: Set[str] = frozenset()) -> _ProtoModule:
+    """Define a protocol buffers module.
+
+    The settings defined here are used for all protobuf messages
+    declared in the module of the given name.
+
+    Args:
+        package (str): The proto package name.
+        marshal (str): The name of the marshal to use. It is recommended
+            to use one marshal per Python library (e.g. package on PyPI).
+        manifest (Tuple[str]): A tuple of classes to be created. Setting
+            this adds a slight efficiency in piecing together proto
+            descriptors under the hood.
+    """
+    if not marshal:
+        marshal = package
+    return _ProtoModule(
+        package=package,
+        marshal=marshal,
+        manifest=frozenset(manifest),
+    )
+
+
+__all__ = (
+    'define_module',
+)

--- a/tests/test_fields_composite_string_ref.py
+++ b/tests/test_fields_composite_string_ref.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import proto
 
 
@@ -31,24 +33,19 @@ def test_composite_forward_ref():
 
 
 def test_composite_forward_ref_with_package():
-    class Spam(proto.Message):
-        foo = proto.Field('Foo', number=1)
+    sys.modules[__name__].__protobuf__ = proto.module(package='abc.def')
+    try:
+        class Spam(proto.Message):
+            foo = proto.Field('Foo', number=1)
 
-        class Meta:
-            package = 'abc.def'
+        class Eggs(proto.Message):
+            foo = proto.Field('abc.def.Foo', number=1)
 
-    class Eggs(proto.Message):
-        foo = proto.Field('abc.def.Foo', number=1)
-
-        class Meta:
-            package = 'abc.def'
-
-    class Foo(proto.Message):
-        bar = proto.Field(proto.STRING, number=1)
-        baz = proto.Field(proto.INT64, number=2)
-
-        class Meta:
-            package = 'abc.def'
+        class Foo(proto.Message):
+            bar = proto.Field(proto.STRING, number=1)
+            baz = proto.Field(proto.INT64, number=2)
+    finally:
+        del sys.modules[__name__].__protobuf__
 
     spam = Spam(foo=Foo(bar='str', baz=42))
     eggs = Eggs(foo=Foo(bar='rts', baz=24))

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -12,16 +12,51 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 from unittest import mock
+import inspect
+import sys
 
 from google.protobuf import wrappers_pb2
 
 import proto
 
 
-def test_message_creation_all():
-    __all__ = ('Foo', 'Bar', 'Baz')  # noqa: F841
+def test_module_package():
+    sys.modules[__name__].__protobuf__ = proto.module(package='spam.eggs.v1')
+    try:
+        class Foo(proto.Message):
+            bar = proto.Field(proto.INT32, number=1)
+
+        marshal = proto.Marshal(name='spam.eggs.v1')
+
+        assert Foo.meta.package == 'spam.eggs.v1'
+        assert Foo.pb() in marshal._rules
+    finally:
+        del sys.modules[__name__].__protobuf__
+
+
+def test_module_package_explicit_marshal():
+    sys.modules[__name__].__protobuf__ = proto.module(
+        package='spam.eggs.v1',
+        marshal='foo',
+    )
+    try:
+        class Foo(proto.Message):
+            bar = proto.Field(proto.INT32, number=1)
+
+        marshal = proto.Marshal(name='foo')
+
+        assert Foo.meta.package == 'spam.eggs.v1'
+        assert Foo.pb() in marshal._rules
+    finally:
+        del sys.modules[__name__].__protobuf__
+
+
+def test_module_manifest():
+    __protobuf__ = proto.module(
+        manifest={'Foo', 'Bar', 'Baz'},
+        package='spam.eggs.v1',
+    )
 
     # We want to fake a module, but modules have attribute access, and
     # `frame.f_locals` is a dictionary. Since we only actually care about


### PR DESCRIPTION
This replaces the magic behavior attached to `__all__`, and the individual `Meta` inner classes.

**Note:** This is a breaking change.