### PR TITLE
feat: add support for proto3 optional fields

### DIFF
--- a/proto/fields.py
+++ b/proto/fields.py
@@ -95,9 +95,6 @@ class Field:
                 # descriptors.
                 proto_type = ProtoType.INT32
 
-            if self.optional:
-                self.oneof = f'_{self.name}'
-
             # Set the descriptor.
             self._descriptor = descriptor_pb2.FieldDescriptorProto(
                 name=self.name,

--- a/proto/fields.py
+++ b/proto/fields.py
@@ -24,7 +24,7 @@ class Field:
 
     def __init__(self, proto_type, *, number: int,
                  message=None, enum=None, oneof: str = None,
-                 json_name: str = None):
+                 json_name: str = None, optional: bool = False):
         # This class is not intended to stand entirely alone;
         # data is augmented by the metaclass for Message.
         self.mcls_data = {}
@@ -49,6 +49,7 @@ class Field:
         self.enum = enum
         self.oneof = oneof
         self.json_name = json_name
+        self.optional = optional
 
         # Fields are neither repeated nor maps.
         # The RepeatedField and MapField subclasses override these values
@@ -102,6 +103,7 @@ class Field:
                 type=proto_type,
                 type_name=type_name,
                 json_name=self.json_name,
+                proto3_optional=self.optional,
             )
 
         # Return the descriptor.

--- a/proto/fields.py
+++ b/proto/fields.py
@@ -47,9 +47,9 @@ class Field:
         self.proto_type = proto_type
         self.message = message
         self.enum = enum
-        self.oneof = oneof
         self.json_name = json_name
         self.optional = optional
+        self.oneof = oneof
 
         # Fields are neither repeated nor maps.
         # The RepeatedField and MapField subclasses override these values
@@ -94,6 +94,9 @@ class Field:
                 # FIXME: Eventually, come back and put in the actual enum
                 # descriptors.
                 proto_type = ProtoType.INT32
+
+            if self.optional:
+                self.oneof = f'_{self.name}'
 
             # Set the descriptor.
             self._descriptor = descriptor_pb2.FieldDescriptorProto(

--- a/proto/message.py
+++ b/proto/message.py
@@ -160,12 +160,12 @@ class MessageMeta(type):
 
         # As per descriptor.proto, all synthetic oneofs must be ordered after
         # 'real' oneofs.
-        opt_attrs = []
+        opt_attrs = {}
         for field in fields:
             if field.optional:
                 field.oneof = "_{}".format(field.name)
                 field.descriptor.oneof_index = oneofs[field.oneof] = len(oneofs)
-                opt_attrs.append(field.name)
+                opt_attrs[field.name] = field.name
 
         # Generating a metaclass dynamically provides class attributes that
         # instances can't see. This provides idiomatically named constants
@@ -176,7 +176,7 @@ class MessageMeta(type):
         #
         # m = MyMessage()
         # MyMessage.field in m
-        mcls = type('AttrsMeta', (mcls,), {a:a for a in opt_attrs})
+        mcls = type('AttrsMeta', (mcls,), opt_attrs)
 
         # Determine the filename.
         # We determine an appropriate proto filename based on the

--- a/proto/message.py
+++ b/proto/message.py
@@ -169,20 +169,14 @@ class MessageMeta(type):
 
         # Generating a metaclass dynamically provides class attributes that
         # instances can't see. This provides idiomatically named constants
-        # that provide the following pattern to check for field presence:
+        # that enable the following pattern to check for field presence:
         #
         # class MyMessage(proto.Message):
         #     field = proto.Field(proto.INT32, number=1, optional=True)
         #
         # m = MyMessage()
         # MyMessage.field in m
-        class AttrsMeta(mcls):
-            pass
-
-        for a in opt_attrs:
-            setattr(mcls, a, a)
-
-        mcls = AttrsMeta
+        mcls = type('AttrsMeta', (mcls,), {a:a for a in opt_attrs})
 
         # Determine the filename.
         # We determine an appropriate proto filename based on the

--- a/proto/message.py
+++ b/proto/message.py
@@ -162,10 +162,10 @@ class MessageMeta(type):
         # 'real' oneofs.
         for field in fields:
             if field.optional:
-                field.oneof = "_{field.name}"
+                field.oneof = "_{}".format(field.name)
                 field.descriptor.oneof_index = oneofs[field.oneof] = len(oneofs)
-                # fget = lambda self: 
-                # attrs[f'_Has_{field.name}']
+                fget = lambda self: self.__class__.pb(self).HasField(field.name)
+                attrs['Has_{}'.format(field.name)] = property(fget, None)
 
         # Determine the filename.
         # We determine an appropriate proto filename based on the

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     platforms='Posix; MacOS X',
     include_package_data=True,
     install_requires=(
-        'protobuf >= 3.5.1',
+        'protobuf >= 3.12.0',
     ),
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tests/test_fields_optional.py
+++ b/tests/test_fields_optional.py
@@ -23,3 +23,6 @@ def test_optional_init():
 
     massive_squid = Squid(mass_kg=20)
     massless_squid = Squid()
+
+    assert massive_squid.Hasmass_kg
+    assert not massless_squid.Hasmass_kg

--- a/tests/test_fields_optional.py
+++ b/tests/test_fields_optional.py
@@ -24,16 +24,19 @@ def test_optional_init():
     squid_1 = Squid(mass_kg=20)
     squid_2 = Squid()
 
-    assert squid_1.Has_mass_kg
+    assert Squid.mass_kg in squid_1
     assert squid_1.mass_kg == 20
-    assert not squid_2.Has_mass_kg
+    assert not Squid.mass_kg in squid_2
 
     squid_2.mass_kg = 30
     assert squid_2.mass_kg == 30
-    assert squid_2.Has_mass_kg
+    assert Squid.mass_kg in squid_2
 
     del squid_1.mass_kg
-    assert not squid_1.Has_mass_kg
+    assert not Squid.mass_kg in squid_1
+
+    with pytest.raises(AttributeError):
+        Squid.shell
 
 
 def test_optional_and_oneof():
@@ -50,12 +53,12 @@ def test_optional_and_oneof():
     s = Squid(mass_kg=20)
     assert s.mass_kg == 20
     assert not s.mass_lbs
-    assert not s.Has_iridiphore_num
+    assert not Squid.iridiphore_num in s
 
     s.iridiphore_num = 600
     assert s.mass_kg == 20
     assert not s.mass_lbs
-    assert s.Has_iridiphore_num
+    assert Squid.iridiphore_num in s
 
     s = Squid(mass_lbs=40, iridiphore_num=600)
     assert not s.mass_kg
@@ -73,7 +76,7 @@ def test_optional_and_oneof():
 
     assert c.mass_kg == 20
     assert not c.mass_lbs
-    assert not c.Has_flute_radius
+    assert not Clam.flute_radius in c
     c.flute_radius = 30
     assert c.mass_kg == 20
     assert not c.mass_lbs

--- a/tests/test_fields_optional.py
+++ b/tests/test_fields_optional.py
@@ -1,0 +1,25 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import proto
+
+
+def test_optional_init():
+    class Squid(proto.Message):
+        mass_kg = proto.Field(proto.INT32, number=1, optional=True)
+
+    massive_squid = Squid(mass_kg=20)
+    massless_squid = Squid()


### PR DESCRIPTION
Due to popular demand, proto3 recently added the concept of field presence. Fields can be marked as 'optional', which is internally represented via a synthetic _oneof.
See https://github.com/protocolbuffers/protobuf/releases/tag/v3.12.0 for additional background and information.

Generated messages can define optional fields, and message classes gain constants that can be used to check for field presence in instances. These constants are not visible to message instances and therefore don't collide with message field names.

Fields can be set as 'optional' using the following syntax

Example:
```python
class Squid(proto.Message):
    mantle = proto.Field(proto.INT32, number=1, optional=True)

s = Squid()
assert not Squid.mantle in s
s.mantle = 2112
assert Squid.mantle in s
```