### PR TITLE
feat: more performance optimizations

### DIFF
--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -216,3 +216,15 @@ def test_invalid_field_access():
     s = Squid()
     with pytest.raises(AttributeError):
         getattr(s, "shell")
+
+
+def test_setattr():
+    class Squid(proto.Message):
+        mass_kg = proto.Field(proto.INT32, number=1)
+
+    s1 = Squid()
+    s2 = Squid(mass_kg=20)
+
+    s1._pb = s2._pb
+
+    assert s1.mass_kg == 20


### PR DESCRIPTION
The two big changes here are bypassing __init__ in a special case and
directly setting instance attributes via reaching into self.__dict__.
These are optimizations in a potential hot path that were isolated via
exhaustive profiling and experimentation and save ~%16 in certain benchmarks.

Do not try this at home.