### PR TITLE
feat: allow enum strings in json serialization and deserialization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,7 +249,7 @@ jobs:
       - run:
           name: Format files
           command: |
-            black .
+            black -l 88 .
       - run:
           name: Check diff
           command: |

--- a/docs/messages.rst
+++ b/docs/messages.rst
@@ -165,3 +165,12 @@ via the :meth:`~.Message.to_json` and :meth:`~.Message.from_json` methods.
 
     new_song = Song.from_json(json)
 
+The behavior of JSON serialization can be customized to use strings to
+represent enum values.
+
+.. code-block:: python
+
+   song = Song(genre=Genre.JAZZ)
+   json = Song.to_json(song, enum_strings=True)
+
+   assert "JAZZ" in json

--- a/docs/messages.rst
+++ b/docs/messages.rst
@@ -171,6 +171,6 @@ represent enum values.
 .. code-block:: python
 
    song = Song(genre=Genre.JAZZ)
-   json = Song.to_json(song, enum_strings=True)
+   json = Song.to_json(song, use_integers_for_enums=True)
 
    assert "JAZZ" in json

--- a/docs/messages.rst
+++ b/docs/messages.rst
@@ -171,6 +171,6 @@ represent enum values.
 .. code-block:: python
 
    song = Song(genre=Genre.JAZZ)
-   json = Song.to_json(song, use_integers_for_enums=True)
+   json = Song.to_json(song, use_integers_for_enums=False)
 
    assert "JAZZ" in json

--- a/proto/_file_info.py
+++ b/proto/_file_info.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections.abc
+import collections
 import inspect
 import logging
 
+from google.protobuf import descriptor_pb2
 from google.protobuf import descriptor_pool
 from google.protobuf import message
 from google.protobuf import reflection
@@ -31,6 +32,26 @@ class _FileInfo(
     )
 ):
     registry = {}  # Mapping[str, '_FileInfo']
+
+    @classmethod
+    def maybe_add_descriptor(cls, filename, package):
+        descriptor = cls.registry.get(filename)
+        if not descriptor:
+            descriptor = cls.registry[filename] = cls(
+                descriptor=descriptor_pb2.FileDescriptorProto(
+                    name=filename, package=package, syntax="proto3",
+                ),
+                enums=collections.OrderedDict(),
+                messages=collections.OrderedDict(),
+                name=filename,
+                nested={},
+            )
+
+        return descriptor
+
+    @staticmethod
+    def proto_file_name(name):
+        return "{0}.proto".format(name).replace(".", "/")
 
     def _get_manifest(self, new_class):
         module = inspect.getmodule(new_class)

--- a/proto/_file_info.py
+++ b/proto/_file_info.py
@@ -39,7 +39,9 @@ class _FileInfo(
         if not descriptor:
             descriptor = cls.registry[filename] = cls(
                 descriptor=descriptor_pb2.FileDescriptorProto(
-                    name=filename, package=package, syntax="proto3",
+                    name=filename,
+                    package=package,
+                    syntax="proto3",
                 ),
                 enums=collections.OrderedDict(),
                 messages=collections.OrderedDict(),

--- a/proto/enums.py
+++ b/proto/enums.py
@@ -70,7 +70,7 @@ class ProtoEnumMeta(enum.EnumMeta):
         # Run the superclass constructor.
         cls = super().__new__(mcls, name, bases, attrs)
 
-        # We can't just add a "_pb" element to attrs because the Enum
+        # We can't just add a "_meta" element to attrs because the Enum
         # machinery doesn't know what to do with a non-int value.
         cls._meta = _EnumInfo(full_name=full_name, pb=enum_desc)
 

--- a/proto/enums.py
+++ b/proto/enums.py
@@ -14,6 +14,9 @@
 
 import enum
 
+from google.protobuf import descriptor_pb2
+
+from proto import _file_info
 from proto import _package_info
 from proto.marshal.rules.enums import EnumRule
 
@@ -30,8 +33,48 @@ class ProtoEnumMeta(enum.EnumMeta):
         # this component belongs within the file.
         package, marshal = _package_info.compile(name, attrs)
 
+        # Determine the local path of this proto component within the file.
+        local_path = tuple(attrs.get("__qualname__", name).split("."))
+
+        # Sanity check: We get the wrong full name if a class is declared
+        # inside a function local scope; correct this.
+        if "<locals>" in local_path:
+            ix = local_path.index("<locals>")
+            local_path = local_path[: ix - 1] + local_path[ix + 1 :]
+
+        # Determine the full name in protocol buffers.
+        # The C++ proto implementation doesn't like dots in names, so use underscores.
+        full_name = "_".join((package,) + local_path).lstrip("_")
+        enum_desc = descriptor_pb2.EnumDescriptorProto(
+            name=full_name,
+            # Note: the superclass ctor removes the variants, so get them now.
+            # Note: proto3 requires that the first variant value be zero.
+            value=sorted(
+                (
+                    descriptor_pb2.EnumValueDescriptorProto(name=name, number=number)
+                    # Minor hack to get all the enum variants out.
+                    for name, number in attrs.items()
+                    if isinstance(number, int)
+                ),
+                key=lambda v: v.number,
+            ),
+        )
+
+        filename = _file_info._FileInfo.proto_file_name(
+            attrs.get("__module__", name.lower())
+        )
+
+        file_info = _file_info._FileInfo.maybe_add_descriptor(filename, package)
+        file_info.descriptor.enum_type.add().MergeFrom(enum_desc)
+
         # Run the superclass constructor.
         cls = super().__new__(mcls, name, bases, attrs)
+
+        # We can't just add a "_pb" element to attrs because the Enum
+        # machinery doesn't know what to do with a non-int value.
+        cls._meta = _EnumInfo(full_name=full_name, pb=enum_desc)
+
+        file_info.enums[full_name] = cls
 
         # Register the enum with the marshal.
         marshal.register(cls, EnumRule(cls))
@@ -44,3 +87,9 @@ class Enum(enum.IntEnum, metaclass=ProtoEnumMeta):
     """A enum object that also builds a protobuf enum descriptor."""
 
     pass
+
+
+class _EnumInfo:
+    def __init__(self, *, full_name: str, pb):
+        self.full_name = full_name
+        self.pb = pb

--- a/proto/fields.py
+++ b/proto/fields.py
@@ -88,19 +88,7 @@ class Field:
                     else self.message.meta.full_name
                 )
             elif self.enum:
-                # Nos decipiat.
-                #
-                # As far as the wire format is concerned, enums are int32s.
-                # Protocol buffers itself also only sends ints; the enum
-                # objects are simply helper classes for translating names
-                # and values and it is the user's job to resolve to an int.
-                #
-                # Therefore, the non-trivial effort of adding the actual
-                # enum descriptors seems to add little or no actual value.
-                #
-                # FIXME: Eventually, come back and put in the actual enum
-                # descriptors.
-                proto_type = ProtoType.INT32
+                type_name = self.enum._meta.full_name
 
             # Set the descriptor.
             self._descriptor = descriptor_pb2.FieldDescriptorProto(

--- a/proto/fields.py
+++ b/proto/fields.py
@@ -78,7 +78,8 @@ class Field:
             if isinstance(self.message, str):
                 if not self.message.startswith(self.package):
                     self.message = "{package}.{name}".format(
-                        package=self.package, name=self.message,
+                        package=self.package,
+                        name=self.message,
                     )
                 type_name = self.message
             elif self.message:

--- a/proto/marshal/marshal.py
+++ b/proto/marshal/marshal.py
@@ -209,7 +209,8 @@ class BaseMarshal:
             raise TypeError(
                 "Parameter must be instance of the same class; "
                 "expected {expected}, got {got}".format(
-                    expected=proto_type.__name__, got=pb_value.__class__.__name__,
+                    expected=proto_type.__name__,
+                    got=pb_value.__class__.__name__,
                 ),
             )
 

--- a/proto/marshal/rules/dates.py
+++ b/proto/marshal/rules/dates.py
@@ -44,7 +44,8 @@ class TimestampRule:
             return value.timestamp_pb()
         if isinstance(value, datetime):
             return timestamp_pb2.Timestamp(
-                seconds=int(value.timestamp()), nanos=value.microsecond * 1000,
+                seconds=int(value.timestamp()),
+                nanos=value.microsecond * 1000,
             )
         return value
 

--- a/proto/marshal/rules/enums.py
+++ b/proto/marshal/rules/enums.py
@@ -36,7 +36,8 @@ class EnumRule:
                 # the user realizes that an unexpected value came along.
                 warnings.warn(
                     "Unrecognized {name} enum value: {value}".format(
-                        name=self._enum.__name__, value=value,
+                        name=self._enum.__name__,
+                        value=value,
                     )
                 )
         return value

--- a/proto/marshal/rules/struct.py
+++ b/proto/marshal/rules/struct.py
@@ -43,11 +43,15 @@ class ValueRule:
             return str(value.string_value)
         if kind == "struct_value":
             return self._marshal.to_python(
-                struct_pb2.Struct, value.struct_value, absent=False,
+                struct_pb2.Struct,
+                value.struct_value,
+                absent=False,
             )
         if kind == "list_value":
             return self._marshal.to_python(
-                struct_pb2.ListValue, value.list_value, absent=False,
+                struct_pb2.ListValue,
+                value.list_value,
+                absent=False,
             )
         raise AttributeError
 
@@ -114,7 +118,9 @@ class StructRule:
         if isinstance(value, struct_pb2.Struct):
             return value
         if isinstance(value, maps.MapComposite):
-            return struct_pb2.Struct(fields={k: v for k, v in value.pb.items()},)
+            return struct_pb2.Struct(
+                fields={k: v for k, v in value.pb.items()},
+            )
 
         # We got a dict (or something dict-like); convert it.
         answer = struct_pb2.Struct(

--- a/proto/message.py
+++ b/proto/message.py
@@ -314,22 +314,22 @@ class MessageMeta(type):
         """
         return cls.wrap(cls.pb().FromString(payload))
 
-    def to_json(cls, instance, *, use_integers_for_enums=False) -> str:
+    def to_json(cls, instance, *, use_integers_for_enums=True) -> str:
         """Given a message instance, serialize it to json
 
         Args:
             instance: An instance of this message type, or something
                 compatible (accepted by the type's constructor).
             use_integers_for_enums (Optional(bool)): An option that determines whether enum
-                values should be represented by strings (True) or integers (False).
-                Default is False.
+                values should be represented by strings (False) or integers (True).
+                Default is True.
 
         Returns:
             str: The json string representation of the protocol buffer.
         """
         return MessageToJson(
             cls.pb(instance),
-            use_integers_for_enums=not use_integers_for_enums,
+            use_integers_for_enums=use_integers_for_enums,
             including_default_value_fields=True,
         )
 

--- a/proto/message.py
+++ b/proto/message.py
@@ -320,6 +320,9 @@ class MessageMeta(type):
         Args:
             instance: An instance of this message type, or something
                 compatible (accepted by the type's constructor).
+            enum_strings (Optional(bool)): An option that determines whether enum
+                values should be represented by strings (True) or integers (False).
+                Default is False.
 
         Returns:
             str: The json string representation of the protocol buffer.

--- a/proto/message.py
+++ b/proto/message.py
@@ -68,7 +68,9 @@ class MessageMeta(type):
             # Determine the name of the entry message.
             msg_name = "{pascal_key}Entry".format(
                 pascal_key=re.sub(
-                    r"_\w", lambda m: m.group()[1:].upper(), key,
+                    r"_\w",
+                    lambda m: m.group()[1:].upper(),
+                    key,
                 ).replace(key[0], key[0].upper(), 1),
             )
 
@@ -84,20 +86,26 @@ class MessageMeta(type):
                 {
                     "__module__": attrs.get("__module__", None),
                     "__qualname__": "{prefix}.{name}".format(
-                        prefix=attrs.get("__qualname__", name), name=msg_name,
+                        prefix=attrs.get("__qualname__", name),
+                        name=msg_name,
                     ),
                     "_pb_options": {"map_entry": True},
                 }
             )
             entry_attrs["key"] = Field(field.map_key_type, number=1)
             entry_attrs["value"] = Field(
-                field.proto_type, number=2, enum=field.enum, message=field.message,
+                field.proto_type,
+                number=2,
+                enum=field.enum,
+                message=field.message,
             )
             map_fields[msg_name] = MessageMeta(msg_name, (Message,), entry_attrs)
 
             # Create the repeated field for the entry message.
             map_fields[key] = RepeatedField(
-                ProtoType.MESSAGE, number=field.number, message=map_fields[msg_name],
+                ProtoType.MESSAGE,
+                number=field.number,
+                message=map_fields[msg_name],
             )
 
         # Add the new entries to the attrs
@@ -275,7 +283,13 @@ class MessageMeta(type):
             if coerce:
                 obj = cls(obj)
             else:
-                raise TypeError("%r is not an instance of %s" % (obj, cls.__name__,))
+                raise TypeError(
+                    "%r is not an instance of %s"
+                    % (
+                        obj,
+                        cls.__name__,
+                    )
+                )
         return obj._pb
 
     def wrap(cls, pb):
@@ -395,7 +409,10 @@ class Message(metaclass=MessageMeta):
             # Sanity check: Did we get something not a map? Error if so.
             raise TypeError(
                 "Invalid constructor input for %s: %r"
-                % (self.__class__.__name__, mapping,)
+                % (
+                    self.__class__.__name__,
+                    mapping,
+                )
             )
         else:
             # Can't have side effects on mapping.

--- a/proto/message.py
+++ b/proto/message.py
@@ -314,13 +314,13 @@ class MessageMeta(type):
         """
         return cls.wrap(cls.pb().FromString(payload))
 
-    def to_json(cls, instance, *, enum_strings=False) -> str:
+    def to_json(cls, instance, *, use_integers_for_enums=False) -> str:
         """Given a message instance, serialize it to json
 
         Args:
             instance: An instance of this message type, or something
                 compatible (accepted by the type's constructor).
-            enum_strings (Optional(bool)): An option that determines whether enum
+            use_integers_for_enums (Optional(bool)): An option that determines whether enum
                 values should be represented by strings (True) or integers (False).
                 Default is False.
 
@@ -329,7 +329,7 @@ class MessageMeta(type):
         """
         return MessageToJson(
             cls.pb(instance),
-            use_integers_for_enums=not enum_strings,
+            use_integers_for_enums=not use_integers_for_enums,
             including_default_value_fields=True,
         )
 

--- a/proto/modules.py
+++ b/proto/modules.py
@@ -17,7 +17,8 @@ import collections
 
 
 _ProtoModule = collections.namedtuple(
-    "ProtoModule", ["package", "marshal", "manifest"],
+    "ProtoModule",
+    ["package", "marshal", "manifest"],
 )
 
 
@@ -39,7 +40,11 @@ def define_module(
     """
     if not marshal:
         marshal = package
-    return _ProtoModule(package=package, marshal=marshal, manifest=frozenset(manifest),)
+    return _ProtoModule(
+        package=package,
+        marshal=marshal,
+        manifest=frozenset(manifest),
+    )
 
 
 __all__ = ("define_module",)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,9 @@ def _register_messages(scope, iterable, sym_db):
     """Create and register messages from the file descriptor."""
     for name, descriptor in iterable.items():
         new_msg = reflection.GeneratedProtocolMessageType(
-            name, (message.Message,), {"DESCRIPTOR": descriptor, "__module__": None},
+            name,
+            (message.Message,),
+            {"DESCRIPTOR": descriptor, "__module__": None},
         )
         sym_db.RegisterMessage(new_msg)
         setattr(scope, name, new_msg)

--- a/tests/test_fields_enum.py
+++ b/tests/test_fields_enum.py
@@ -252,3 +252,16 @@ def test_enum_del():
     assert "color" not in foo
     assert not foo.color
     assert Foo.pb(foo).color == 0
+
+
+class Zone(proto.Enum):
+    EPIPELAGIC = 0
+    MESOPELAGIC = 1
+    ABYSSOPELAGIC = 2
+    HADOPELAGIC = 3
+
+
+def test_enum_outest():
+    z = Zone(value=Zone.MESOPELAGIC)
+
+    assert z == Zone.MESOPELAGIC

--- a/tests/test_fields_map_composite.py
+++ b/tests/test_fields_map_composite.py
@@ -22,7 +22,12 @@ def test_composite_map():
         bar = proto.Field(proto.INT32, number=1)
 
     class Baz(proto.Message):
-        foos = proto.MapField(proto.STRING, proto.MESSAGE, number=1, message=Foo,)
+        foos = proto.MapField(
+            proto.STRING,
+            proto.MESSAGE,
+            number=1,
+            message=Foo,
+        )
 
     baz = Baz(foos={"i": Foo(bar=42), "j": Foo(bar=24)})
     assert len(baz.foos) == 2
@@ -36,7 +41,12 @@ def test_composite_map_dict():
         bar = proto.Field(proto.INT32, number=1)
 
     class Baz(proto.Message):
-        foos = proto.MapField(proto.STRING, proto.MESSAGE, number=1, message=Foo,)
+        foos = proto.MapField(
+            proto.STRING,
+            proto.MESSAGE,
+            number=1,
+            message=Foo,
+        )
 
     baz = Baz(foos={"i": {"bar": 42}, "j": {"bar": 24}})
     assert len(baz.foos) == 2
@@ -52,7 +62,12 @@ def test_composite_map_set():
         bar = proto.Field(proto.INT32, number=1)
 
     class Baz(proto.Message):
-        foos = proto.MapField(proto.STRING, proto.MESSAGE, number=1, message=Foo,)
+        foos = proto.MapField(
+            proto.STRING,
+            proto.MESSAGE,
+            number=1,
+            message=Foo,
+        )
 
     baz = Baz()
     baz.foos["i"] = Foo(bar=42)
@@ -68,7 +83,12 @@ def test_composite_map_deep_set():
         bar = proto.Field(proto.INT32, number=1)
 
     class Baz(proto.Message):
-        foos = proto.MapField(proto.STRING, proto.MESSAGE, number=1, message=Foo,)
+        foos = proto.MapField(
+            proto.STRING,
+            proto.MESSAGE,
+            number=1,
+            message=Foo,
+        )
 
     baz = Baz()
     baz.foos["i"] = Foo()
@@ -82,7 +102,12 @@ def test_composite_map_del():
         bar = proto.Field(proto.INT32, number=1)
 
     class Baz(proto.Message):
-        foos = proto.MapField(proto.STRING, proto.MESSAGE, number=1, message=Foo,)
+        foos = proto.MapField(
+            proto.STRING,
+            proto.MESSAGE,
+            number=1,
+            message=Foo,
+        )
 
     baz = Baz()
     baz.foos["i"] = Foo(bar=42)

--- a/tests/test_fields_repeated_composite.py
+++ b/tests/test_fields_repeated_composite.py
@@ -74,7 +74,9 @@ def test_repeated_composite_falsy_behavior():
 def test_repeated_composite_marshaled():
     class Foo(proto.Message):
         timestamps = proto.RepeatedField(
-            proto.MESSAGE, message=timestamp_pb2.Timestamp, number=1,
+            proto.MESSAGE,
+            message=timestamp_pb2.Timestamp,
+            number=1,
         )
 
     foo = Foo(

--- a/tests/test_file_info_salting.py
+++ b/tests/test_file_info_salting.py
@@ -34,7 +34,9 @@ def sample_file_info(name):
         filename,
         _file_info._FileInfo(
             descriptor=descriptor_pb2.FileDescriptorProto(
-                name=filename, package=package, syntax="proto3",
+                name=filename,
+                package=package,
+                syntax="proto3",
             ),
             enums=collections.OrderedDict(),
             messages=collections.OrderedDict(),

--- a/tests/test_file_info_salting_with_manifest.py
+++ b/tests/test_file_info_salting_with_manifest.py
@@ -21,7 +21,10 @@ from google.protobuf import descriptor_pb2
 from proto import _file_info, _package_info
 
 PACKAGE = "a.test.package.salting.with.manifest"
-__protobuf__ = proto.module(package=PACKAGE, manifest={"This", "That"},)
+__protobuf__ = proto.module(
+    package=PACKAGE,
+    manifest={"This", "That"},
+)
 
 
 class This(proto.Message):
@@ -49,7 +52,9 @@ def sample_file_info(name):
         filename,
         _file_info._FileInfo(
             descriptor=descriptor_pb2.FileDescriptorProto(
-                name=filename, package=package, syntax="proto3",
+                name=filename,
+                package=package,
+                syntax="proto3",
             ),
             enums=collections.OrderedDict(),
             messages=collections.OrderedDict(),

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -50,3 +50,41 @@ def test_message_json_round_trip():
     s2 = Squid.from_json(json)
 
     assert s == s2
+
+
+def test_stringy_enums():
+    class Zone(proto.Enum):
+        EPIPELAGIC = 0
+        MESOPELAGIC = 1
+        BATHYPELAGIC = 2
+        ABYSSOPELAGIC = 3
+
+    class Squid(proto.Message):
+        zone = proto.Field(Zone, number=1)
+
+    s1 = Squid(zone=Zone.MESOPELAGIC)
+    json = Squid.to_json(s1, enum_strings=True)
+
+    assert "MESOPELAGIC" in json
+
+    s2 = Squid.from_json(json)
+    assert s2.zone == s1.zone
+
+
+def test_default_enums():
+    class Zone(proto.Enum):
+        EPIPELAGIC = 0
+        MESOPELAGIC = 1
+        BATHYPELAGIC = 2
+        ABYSSOPELAGIC = 3
+
+    class Squid(proto.Message):
+        zone = proto.Field(Zone, number=1)
+
+    s = Squid()
+    assert s.zone == Zone.EPIPELAGIC
+    json1 = Squid.to_json(s).replace(" ", "").replace("\n", "")
+    assert json1 == '{"zone":0}'
+
+    json2 = Squid.to_json(s, enum_strings=True)
+    assert "EPIPELAGIC" in json2

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -63,7 +63,7 @@ def test_stringy_enums():
         zone = proto.Field(Zone, number=1)
 
     s1 = Squid(zone=Zone.MESOPELAGIC)
-    json = Squid.to_json(s1, enum_strings=True)
+    json = Squid.to_json(s1, use_integers_for_enums=True)
 
     assert "MESOPELAGIC" in json
 
@@ -86,5 +86,5 @@ def test_default_enums():
     json1 = Squid.to_json(s).replace(" ", "").replace("\n", "")
     assert json1 == '{"zone":0}'
 
-    json2 = Squid.to_json(s, enum_strings=True)
+    json2 = Squid.to_json(s, use_integers_for_enums=True)
     assert "EPIPELAGIC" in json2

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -63,7 +63,7 @@ def test_stringy_enums():
         zone = proto.Field(Zone, number=1)
 
     s1 = Squid(zone=Zone.MESOPELAGIC)
-    json = Squid.to_json(s1, use_integers_for_enums=True)
+    json = Squid.to_json(s1, use_integers_for_enums=False)
 
     assert "MESOPELAGIC" in json
 
@@ -86,5 +86,5 @@ def test_default_enums():
     json1 = Squid.to_json(s).replace(" ", "").replace("\n", "")
     assert json1 == '{"zone":0}'
 
-    json2 = Squid.to_json(s, use_integers_for_enums=True)
+    json2 = Squid.to_json(s, use_integers_for_enums=False)
     assert "EPIPELAGIC" in json2

--- a/tests/test_marshal_types_dates.py
+++ b/tests/test_marshal_types_dates.py
@@ -28,7 +28,9 @@ from proto.datetime_helpers import DatetimeWithNanoseconds
 def test_timestamp_read():
     class Foo(proto.Message):
         event_time = proto.Field(
-            proto.MESSAGE, number=1, message=timestamp_pb2.Timestamp,
+            proto.MESSAGE,
+            number=1,
+            message=timestamp_pb2.Timestamp,
         )
 
     foo = Foo(event_time=timestamp_pb2.Timestamp(seconds=1335020400))
@@ -45,7 +47,9 @@ def test_timestamp_read():
 def test_timestamp_write_init():
     class Foo(proto.Message):
         event_time = proto.Field(
-            proto.MESSAGE, number=1, message=timestamp_pb2.Timestamp,
+            proto.MESSAGE,
+            number=1,
+            message=timestamp_pb2.Timestamp,
         )
 
     foo = Foo(event_time=DatetimeWithNanoseconds(2012, 4, 21, 15, tzinfo=timezone.utc))
@@ -60,7 +64,9 @@ def test_timestamp_write_init():
 def test_timestamp_write():
     class Foo(proto.Message):
         event_time = proto.Field(
-            proto.MESSAGE, number=1, message=timestamp_pb2.Timestamp,
+            proto.MESSAGE,
+            number=1,
+            message=timestamp_pb2.Timestamp,
         )
 
     foo = Foo()
@@ -77,7 +83,9 @@ def test_timestamp_write():
 def test_timestamp_write_pb2():
     class Foo(proto.Message):
         event_time = proto.Field(
-            proto.MESSAGE, number=1, message=timestamp_pb2.Timestamp,
+            proto.MESSAGE,
+            number=1,
+            message=timestamp_pb2.Timestamp,
         )
 
     foo = Foo()
@@ -93,7 +101,9 @@ def test_timestamp_write_pb2():
 def test_timestamp_rmw_nanos():
     class Foo(proto.Message):
         event_time = proto.Field(
-            proto.MESSAGE, number=1, message=timestamp_pb2.Timestamp,
+            proto.MESSAGE,
+            number=1,
+            message=timestamp_pb2.Timestamp,
         )
 
     foo = Foo()
@@ -110,7 +120,9 @@ def test_timestamp_rmw_nanos():
 def test_timestamp_absence():
     class Foo(proto.Message):
         event_time = proto.Field(
-            proto.MESSAGE, number=1, message=timestamp_pb2.Timestamp,
+            proto.MESSAGE,
+            number=1,
+            message=timestamp_pb2.Timestamp,
         )
 
     foo = Foo()
@@ -120,7 +132,9 @@ def test_timestamp_absence():
 def test_timestamp_del():
     class Foo(proto.Message):
         event_time = proto.Field(
-            proto.MESSAGE, number=1, message=timestamp_pb2.Timestamp,
+            proto.MESSAGE,
+            number=1,
+            message=timestamp_pb2.Timestamp,
         )
 
     foo = Foo(event_time=DatetimeWithNanoseconds(2012, 4, 21, 15, tzinfo=timezone.utc))
@@ -130,7 +144,11 @@ def test_timestamp_del():
 
 def test_duration_read():
     class Foo(proto.Message):
-        ttl = proto.Field(proto.MESSAGE, number=1, message=duration_pb2.Duration,)
+        ttl = proto.Field(
+            proto.MESSAGE,
+            number=1,
+            message=duration_pb2.Duration,
+        )
 
     foo = Foo(ttl=duration_pb2.Duration(seconds=60, nanos=1000))
     assert isinstance(foo.ttl, timedelta)
@@ -142,7 +160,11 @@ def test_duration_read():
 
 def test_duration_write_init():
     class Foo(proto.Message):
-        ttl = proto.Field(proto.MESSAGE, number=1, message=duration_pb2.Duration,)
+        ttl = proto.Field(
+            proto.MESSAGE,
+            number=1,
+            message=duration_pb2.Duration,
+        )
 
     foo = Foo(ttl=timedelta(days=2))
     assert isinstance(foo.ttl, timedelta)
@@ -155,7 +177,11 @@ def test_duration_write_init():
 
 def test_duration_write():
     class Foo(proto.Message):
-        ttl = proto.Field(proto.MESSAGE, number=1, message=duration_pb2.Duration,)
+        ttl = proto.Field(
+            proto.MESSAGE,
+            number=1,
+            message=duration_pb2.Duration,
+        )
 
     foo = Foo()
     foo.ttl = timedelta(seconds=120)
@@ -167,7 +193,11 @@ def test_duration_write():
 
 def test_duration_write_pb2():
     class Foo(proto.Message):
-        ttl = proto.Field(proto.MESSAGE, number=1, message=duration_pb2.Duration,)
+        ttl = proto.Field(
+            proto.MESSAGE,
+            number=1,
+            message=duration_pb2.Duration,
+        )
 
     foo = Foo()
     foo.ttl = duration_pb2.Duration(seconds=120)
@@ -179,7 +209,11 @@ def test_duration_write_pb2():
 
 def test_duration_del():
     class Foo(proto.Message):
-        ttl = proto.Field(proto.MESSAGE, number=1, message=duration_pb2.Duration,)
+        ttl = proto.Field(
+            proto.MESSAGE,
+            number=1,
+            message=duration_pb2.Duration,
+        )
 
     foo = Foo(ttl=timedelta(seconds=900))
     del foo.ttl
@@ -191,7 +225,11 @@ def test_duration_del():
 
 def test_duration_nanos_rmw():
     class Foo(proto.Message):
-        ttl = proto.Field(proto.MESSAGE, number=1, message=duration_pb2.Duration,)
+        ttl = proto.Field(
+            proto.MESSAGE,
+            number=1,
+            message=duration_pb2.Duration,
+        )
 
     foo = Foo(ttl=timedelta(microseconds=50))
     assert foo.ttl.microseconds == 50

--- a/tests/test_marshal_types_wrappers_bool.py
+++ b/tests/test_marshal_types_wrappers_bool.py
@@ -20,7 +20,11 @@ from proto.marshal.marshal import BaseMarshal
 
 def test_bool_value_init():
     class Foo(proto.Message):
-        bar = proto.Field(proto.MESSAGE, message=wrappers_pb2.BoolValue, number=1,)
+        bar = proto.Field(
+            proto.MESSAGE,
+            message=wrappers_pb2.BoolValue,
+            number=1,
+        )
 
     assert Foo(bar=True).bar is True
     assert Foo(bar=False).bar is False
@@ -29,7 +33,11 @@ def test_bool_value_init():
 
 def test_bool_value_init_dict():
     class Foo(proto.Message):
-        bar = proto.Field(proto.MESSAGE, message=wrappers_pb2.BoolValue, number=1,)
+        bar = proto.Field(
+            proto.MESSAGE,
+            message=wrappers_pb2.BoolValue,
+            number=1,
+        )
 
     assert Foo({"bar": True}).bar is True
     assert Foo({"bar": False}).bar is False
@@ -38,7 +46,11 @@ def test_bool_value_init_dict():
 
 def test_bool_value_distinction_from_bool():
     class Foo(proto.Message):
-        bar = proto.Field(proto.MESSAGE, message=wrappers_pb2.BoolValue, number=1,)
+        bar = proto.Field(
+            proto.MESSAGE,
+            message=wrappers_pb2.BoolValue,
+            number=1,
+        )
         baz = proto.Field(proto.BOOL, number=2)
 
     assert Foo().bar is None
@@ -63,7 +75,11 @@ def test_bool_value_rmw():
 
 def test_bool_value_write_bool_value():
     class Foo(proto.Message):
-        bar = proto.Field(proto.MESSAGE, message=wrappers_pb2.BoolValue, number=1,)
+        bar = proto.Field(
+            proto.MESSAGE,
+            message=wrappers_pb2.BoolValue,
+            number=1,
+        )
 
     foo = Foo(bar=True)
     foo.bar = wrappers_pb2.BoolValue()
@@ -72,7 +88,11 @@ def test_bool_value_write_bool_value():
 
 def test_bool_value_del():
     class Foo(proto.Message):
-        bar = proto.Field(proto.MESSAGE, message=wrappers_pb2.BoolValue, number=1,)
+        bar = proto.Field(
+            proto.MESSAGE,
+            message=wrappers_pb2.BoolValue,
+            number=1,
+        )
 
     foo = Foo(bar=False)
     assert foo.bar is False

--- a/tests/test_message_filename_with_and_without_manifest.py
+++ b/tests/test_message_filename_with_and_without_manifest.py
@@ -16,7 +16,10 @@ import proto
 
 
 PACKAGE = "a.test.package.with.and.without.manifest"
-__protobuf__ = proto.module(package=PACKAGE, manifest={"This", "That"},)
+__protobuf__ = proto.module(
+    package=PACKAGE,
+    manifest={"This", "That"},
+)
 
 
 class This(proto.Message):

--- a/tests/test_message_filename_with_manifest.py
+++ b/tests/test_message_filename_with_manifest.py
@@ -15,7 +15,10 @@
 import proto
 
 PACKAGE = "a.test.package.with.manifest"
-__protobuf__ = proto.module(package=PACKAGE, manifest={"ThisFoo", "ThisBar"},)
+__protobuf__ = proto.module(
+    package=PACKAGE,
+    manifest={"ThisFoo", "ThisBar"},
+)
 
 
 class ThisFoo(proto.Message):

--- a/tests/test_message_nested.py
+++ b/tests/test_message_nested.py
@@ -56,7 +56,8 @@ def test_forking_nested_messages():
         baz = proto.Field(proto.MESSAGE, number=2, message=Baz)
 
     foo = Foo(
-        bar={"spam": "xyz", "eggs": False}, baz=Foo.Baz(bacon=Foo.Baz.Bacon(value=42)),
+        bar={"spam": "xyz", "eggs": False},
+        baz=Foo.Baz(bacon=Foo.Baz.Bacon(value=42)),
     )
     assert foo.bar.spam == "xyz"
     assert not foo.bar.eggs

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -38,7 +38,8 @@ def test_module_package():
 
 def test_module_package_explicit_marshal():
     sys.modules[__name__].__protobuf__ = proto.module(
-        package="spam.eggs.v1", marshal="foo",
+        package="spam.eggs.v1",
+        marshal="foo",
     )
     try:
 
@@ -54,7 +55,10 @@ def test_module_package_explicit_marshal():
 
 
 def test_module_manifest():
-    __protobuf__ = proto.module(manifest={"Foo", "Bar", "Baz"}, package="spam.eggs.v1",)
+    __protobuf__ = proto.module(
+        manifest={"Foo", "Bar", "Baz"},
+        package="spam.eggs.v1",
+    )
 
     # We want to fake a module, but modules have attribute access, and
     # `frame.f_locals` is a dictionary. Since we only actually care about


### PR DESCRIPTION
For protobuf messages that contain enum fields, it is now possible to
specify that enum variants should be serialized as names and not as integers.

E.g.

json_str = MyMessage.to_json(my_message, enum_strings=True)

Similarly, serialization from json that uses this convention is now supported.

This is useful for interoperation with other data sources that do use
strings to define enum variants in json serialization; and for
debugging, where visually inspecting data structures can be helpful,
and variant names are more informative than numerical values.