### PR TITLE
feat: json serialization and deserialization support stringy enums

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -30,11 +30,16 @@ def unit(session, proto="python"):
         "py.test",
         "-W=error",
         "--quiet",
-        "--cov=proto",
-        "--cov-config=.coveragerc",
-        "--cov-report=term",
-        "--cov-report=html",
-        *(session.posargs or [os.path.join("tests", "")]),
+        *(
+            session.posargs  # Coverage info when running individual tests is annoying.
+            or [
+                "--cov=proto",
+                "--cov-config=.coveragerc",
+                "--cov-report=term",
+                "--cov-report=html",
+                os.path.join("tests", ""),
+            ]
+        ),
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,7 +34,7 @@ def unit(session, proto="python"):
         "--cov-config=.coveragerc",
         "--cov-report=term",
         "--cov-report=html",
-        os.path.join("tests", ""),
+        *(session.posargs or [os.path.join("tests", "")]),
     )
 
 

--- a/proto/_file_info.py
+++ b/proto/_file_info.py
@@ -53,7 +53,7 @@ class _FileInfo(
 
     @staticmethod
     def proto_file_name(name):
-        return "{0}.proto".format(name).replace(".", "/")
+        return "{0}.proto".format(name.replace(".", "/"))
 
     def _get_manifest(self, new_class):
         module = inspect.getmodule(new_class)
@@ -130,6 +130,13 @@ class _FileInfo(
             for field in proto_plus_message._meta.fields.values():
                 if field.message and isinstance(field.message, str):
                     field.message = self.messages[field.message]
+                elif field.enum and isinstance(field.enum, str):
+                    field.enum = self.enums[field.enum]
+
+        # Same thing for enums
+        for full_name, proto_plus_enum in self.enums.items():
+            descriptor = pool.FindEnumTypeByName(full_name)
+            proto_plus_enum._meta.pb = descriptor
 
         # We no longer need to track this file's info; remove it from
         # the module's registry and from this object.
@@ -153,14 +160,16 @@ class _FileInfo(
         """
         # If there are any nested descriptors that have not been assigned to
         # the descriptors that should contain them, then we are not ready.
-        if len(self.nested):
+        if len(self.nested) or len(self.nested_enum):
             return False
 
         # If there are any unresolved fields (fields with a composite message
         # declared as a string), ensure that the corresponding message is
         # declared.
         for field in self.unresolved_fields:
-            if field.message not in self.messages:
+            if (field.message and field.message not in self.messages) or (
+                field.enum and field.enum not in self.enums
+            ):
                 return False
 
         # If the module in which this class is defined provides a
@@ -179,5 +188,7 @@ class _FileInfo(
         """Return fields with referencing message types as strings."""
         for proto_plus_message in self.messages.values():
             for field in proto_plus_message._meta.fields.values():
-                if field.message and isinstance(field.message, str):
+                if (field.message and isinstance(field.message, str)) or (
+                    field.enum and isinstance(field.enum, str)
+                ):
                     yield field

--- a/proto/_file_info.py
+++ b/proto/_file_info.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections.abc
+import collections
 import inspect
 import logging
 
+from google.protobuf import descriptor_pb2
 from google.protobuf import descriptor_pool
 from google.protobuf import message
 from google.protobuf import reflection
@@ -27,10 +28,32 @@ log = logging.getLogger("_FileInfo")
 
 class _FileInfo(
     collections.namedtuple(
-        "_FileInfo", ["descriptor", "messages", "enums", "name", "nested"]
+        "_FileInfo",
+        ["descriptor", "messages", "enums", "name", "nested", "nested_enum"],
     )
 ):
     registry = {}  # Mapping[str, '_FileInfo']
+
+    @classmethod
+    def maybe_add_descriptor(cls, filename, package):
+        descriptor = cls.registry.get(filename)
+        if not descriptor:
+            descriptor = cls.registry[filename] = cls(
+                descriptor=descriptor_pb2.FileDescriptorProto(
+                    name=filename, package=package, syntax="proto3",
+                ),
+                enums=collections.OrderedDict(),
+                messages=collections.OrderedDict(),
+                name=filename,
+                nested={},
+                nested_enum={},
+            )
+
+        return descriptor
+
+    @staticmethod
+    def proto_file_name(name):
+        return "{0}.proto".format(name).replace(".", "/")
 
     def _get_manifest(self, new_class):
         module = inspect.getmodule(new_class)

--- a/proto/enums.py
+++ b/proto/enums.py
@@ -14,6 +14,9 @@
 
 import enum
 
+from google.protobuf import descriptor_pb2
+
+from proto import _file_info
 from proto import _package_info
 from proto.marshal.rules.enums import EnumRule
 
@@ -30,8 +33,50 @@ class ProtoEnumMeta(enum.EnumMeta):
         # this component belongs within the file.
         package, marshal = _package_info.compile(name, attrs)
 
+        # Determine the local path of this proto component within the file.
+        local_path = tuple(attrs.get("__qualname__", name).split("."))
+
+        # Sanity check: We get the wrong full name if a class is declared
+        # inside a function local scope; correct this.
+        if "<locals>" in local_path:
+            ix = local_path.index("<locals>")
+            local_path = local_path[: ix - 1] + local_path[ix + 1 :]
+
+        # Determine the full name in protocol buffers.
+        full_name = ".".join((package,) + local_path).lstrip(".")
+        enum_desc = descriptor_pb2.EnumDescriptorProto(
+            name=name,
+            # Note: the superclass ctor removes the variants, so get them now.
+            # Note: proto3 requires that the first variant value be zero.
+            value=sorted(
+                (
+                    descriptor_pb2.EnumValueDescriptorProto(name=name, number=number)
+                    # Minor hack to get all the enum variants out.
+                    for name, number in attrs.items()
+                    if isinstance(number, int)
+                ),
+                key=lambda v: v.number,
+            ),
+        )
+
+        filename = _file_info._FileInfo.proto_file_name(
+            attrs.get("__module__", name.lower())
+        )
+
+        file_info = _file_info._FileInfo.maybe_add_descriptor(filename, package)
+        if len(local_path) == 1:
+            file_info.descriptor.enum_type.add().MergeFrom(enum_desc)
+        else:
+            file_info.nested_enum[local_path] = enum_desc
+
         # Run the superclass constructor.
         cls = super().__new__(mcls, name, bases, attrs)
+
+        # We can't just add a "_meta" element to attrs because the Enum
+        # machinery doesn't know what to do with a non-int value.
+        cls._meta = _EnumInfo(full_name=full_name, pb=enum_desc)
+
+        file_info.enums[full_name] = cls
 
         # Register the enum with the marshal.
         marshal.register(cls, EnumRule(cls))
@@ -44,3 +89,9 @@ class Enum(enum.IntEnum, metaclass=ProtoEnumMeta):
     """A enum object that also builds a protobuf enum descriptor."""
 
     pass
+
+
+class _EnumInfo:
+    def __init__(self, *, full_name: str, pb):
+        self.full_name = full_name
+        self.pb = pb

--- a/proto/fields.py
+++ b/proto/fields.py
@@ -88,19 +88,7 @@ class Field:
                     else self.message.meta.full_name
                 )
             elif self.enum:
-                # Nos decipiat.
-                #
-                # As far as the wire format is concerned, enums are int32s.
-                # Protocol buffers itself also only sends ints; the enum
-                # objects are simply helper classes for translating names
-                # and values and it is the user's job to resolve to an int.
-                #
-                # Therefore, the non-trivial effort of adding the actual
-                # enum descriptors seems to add little or no actual value.
-                #
-                # FIXME: Eventually, come back and put in the actual enum
-                # descriptors.
-                proto_type = ProtoType.INT32
+                type_name = self.enum._meta.full_name
 
             # Set the descriptor.
             self._descriptor = descriptor_pb2.FieldDescriptorProto(

--- a/proto/fields.py
+++ b/proto/fields.py
@@ -94,11 +94,7 @@ class Field:
                     )
                 type_name = self.enum
             elif self.enum:
-                type_name = (
-                    self.enum.DESCRIPTOR.full_name
-                    if hasattr(self.enum, "DESCRIPTOR")
-                    else self.enum._meta.full_name
-                )
+                type_name = self.enum._meta.full_name
 
             # Set the descriptor.
             self._descriptor = descriptor_pb2.FieldDescriptorProto(

--- a/proto/fields.py
+++ b/proto/fields.py
@@ -72,7 +72,6 @@ class Field:
     def descriptor(self):
         """Return the descriptor for the field."""
         if not self._descriptor:
-            proto_type = self.proto_type
             # Resolve the message type, if any, to a string.
             type_name = None
             if isinstance(self.message, str):
@@ -101,7 +100,7 @@ class Field:
                 name=self.name,
                 number=self.number,
                 label=3 if self.repeated else 1,
-                type=proto_type,
+                type=self.proto_type,
                 type_name=type_name,
                 json_name=self.json_name,
                 proto3_optional=self.optional,

--- a/proto/fields.py
+++ b/proto/fields.py
@@ -85,10 +85,20 @@ class Field:
                 type_name = (
                     self.message.DESCRIPTOR.full_name
                     if hasattr(self.message, "DESCRIPTOR")
-                    else self.message.meta.full_name
+                    else self.message._meta.full_name
                 )
+            elif isinstance(self.enum, str):
+                if not self.enum.startswith(self.package):
+                    self.enum = "{package}.{name}".format(
+                        package=self.package, name=self.enum,
+                    )
+                type_name = self.enum
             elif self.enum:
-                type_name = self.enum._meta.full_name
+                type_name = (
+                    self.enum.DESCRIPTOR.full_name
+                    if hasattr(self.enum, "DESCRIPTOR")
+                    else self.enum._meta.full_name
+                )
 
             # Set the descriptor.
             self._descriptor = descriptor_pb2.FieldDescriptorProto(

--- a/proto/message.py
+++ b/proto/message.py
@@ -153,7 +153,6 @@ class MessageMeta(type):
                 # correctly when the file descriptor is created later.
                 if field_msg:
                     proto_imports.add(field_msg.DESCRIPTOR.file.name)
-                    symbol_database.Default().RegisterMessage(field_msg)
 
             # Same thing, but for enums.
             elif field.enum and not isinstance(field.enum, str):

--- a/proto/message.py
+++ b/proto/message.py
@@ -160,7 +160,6 @@ class MessageMeta(type):
 
                 if field_enum:
                     proto_imports.add(field_enum.file.name)
-                    symbol_database.Default().RegisterEnumDescriptor(field_enum)
 
             # Increment the field index counter.
             index += 1

--- a/proto/message.py
+++ b/proto/message.py
@@ -145,7 +145,6 @@ class MessageMeta(type):
                 field_msg = field.message
                 if hasattr(field_msg, "pb") and callable(field_msg.pb):
                     field_msg = field_msg.pb()
-
                 # Sanity check: The field's message may not yet be defined if
                 # it was a Message defined in the same file, and the file
                 # descriptor proto has not yet been generated.
@@ -155,6 +154,14 @@ class MessageMeta(type):
                 if field_msg:
                     proto_imports.add(field_msg.DESCRIPTOR.file.name)
                     symbol_database.Default().RegisterMessage(field_msg)
+
+            # Same thing, but for enums.
+            elif field.enum and not isinstance(field.enum, str):
+                field_enum = field.enum._meta.pb
+
+                if field_enum:
+                    proto_imports.add(field_enum.file.name)
+                    symbol_database.Default().RegisterEnumDescriptor(field_enum)
 
             # Increment the field index counter.
             index += 1

--- a/proto/message.py
+++ b/proto/message.py
@@ -183,24 +183,13 @@ class MessageMeta(type):
         # Determine the filename.
         # We determine an appropriate proto filename based on the
         # Python module.
-        filename = "{0}.proto".format(
-            new_attrs.get("__module__", name.lower()).replace(".", "/")
+        filename = _file_info._FileInfo.proto_file_name(
+            new_attrs.get("__module__", name.lower())
         )
 
         # Get or create the information about the file, including the
         # descriptor to which the new message descriptor shall be added.
-        file_info = _file_info._FileInfo.registry.setdefault(
-            filename,
-            _file_info._FileInfo(
-                descriptor=descriptor_pb2.FileDescriptorProto(
-                    name=filename, package=package, syntax="proto3",
-                ),
-                enums=collections.OrderedDict(),
-                messages=collections.OrderedDict(),
-                name=filename,
-                nested={},
-            ),
-        )
+        file_info = _file_info._FileInfo.maybe_add_descriptor(filename, package)
 
         # Ensure any imports that would be necessary are assigned to the file
         # descriptor proto being created.
@@ -226,6 +215,11 @@ class MessageMeta(type):
         child_paths = [p for p in file_info.nested.keys() if local_path == p[:-1]]
         for child_path in child_paths:
             desc.nested_type.add().MergeFrom(file_info.nested.pop(child_path))
+
+        # Same thing, but for enums
+        child_paths = [p for p in file_info.nested_enum.keys() if local_path == p[:-1]]
+        for child_path in child_paths:
+            desc.enum_type.add().MergeFrom(file_info.nested_enum.pop(child_path))
 
         # Add the descriptor to the file if it is a top-level descriptor,
         # or to a "holding area" for nested messages otherwise.
@@ -325,17 +319,24 @@ class MessageMeta(type):
         """
         return cls.wrap(cls.pb().FromString(payload))
 
-    def to_json(cls, instance) -> str:
+    def to_json(cls, instance, *, use_integers_for_enums=True) -> str:
         """Given a message instance, serialize it to json
 
         Args:
             instance: An instance of this message type, or something
                 compatible (accepted by the type's constructor).
+            use_integers_for_enums (Optional(bool)): An option that determines whether enum
+                values should be represented by strings (False) or integers (True).
+                Default is True.
 
         Returns:
             str: The json string representation of the protocol buffer.
         """
-        return MessageToJson(cls.pb(instance))
+        return MessageToJson(
+            cls.pb(instance),
+            use_integers_for_enums=use_integers_for_enums,
+            including_default_value_fields=True,
+        )
 
     def from_json(cls, payload) -> "Message":
         """Given a json string representing an instance,

--- a/tests/clam.py
+++ b/tests/clam.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2020  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import proto
+
+__protobuf__ = proto.module(package="ocean.clam.v1", manifest={"Clam", "Species",},)
+
+
+class Species(proto.Enum):
+    UNKNOWN = 0
+    SQUAMOSA = 1
+    DURASA = 2
+    GIGAS = 3
+
+
+class Clam(proto.Message):
+    species = proto.Field(proto.ENUM, number=1, enum="Species")
+    mass_kg = proto.Field(proto.DOUBLE, number=2)

--- a/tests/mollusc.py
+++ b/tests/mollusc.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2020  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import proto
+import zone
+
+__protobuf__ = proto.module(package="ocean.mollusc.v1", manifest={"Mollusc",},)
+
+
+class Mollusc(proto.Message):
+    zone = proto.Field(zone.Zone, number=1)

--- a/tests/test_fields_enum.py
+++ b/tests/test_fields_enum.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import proto
+import sys
 
 
 def test_outer_enum_init():
@@ -285,9 +286,42 @@ def test_nested_enum_from_string():
         # checks for valid variants.
         # Similarly, constructing a message directly with a top level 
         # enum field kwarg passed as a string is also handled correctly, i.e.
-        # s = Squid(zone="ABYSSAL")
+        # s = Squid(zone="ABYSSOPELAGIC")
         # does NOT raise an exception.
         squids = proto.RepeatedField(Squid, number=1)
 
     t = Trawl(squids=[{"zone": "MESOPELAGIC"}])
     assert t.squids[0] == Squid(zone=Zone.MESOPELAGIC)
+
+
+def test_enum_field_by_string():
+    class Zone(proto.Enum):
+        EPIPELAGIC = 0
+        MESOPELAGIC = 1
+        BATHYPELAGIC = 2
+        ABYSSOPELAGIC = 3
+
+    class Squid(proto.Message):
+        zone = proto.Field(proto.ENUM, number=1, enum="Zone")
+
+    s = Squid(zone=Zone.BATHYPELAGIC)
+    assert s.zone == Zone.BATHYPELAGIC
+
+
+def test_enum_field_by_string_with_package():
+    sys.modules[__name__].__protobuf__ = proto.module(package="mollusca.cephalopoda")
+    try:
+        class Zone(proto.Enum):
+            EPIPELAGIC = 0
+            MESOPELAGIC = 1
+            BATHYPELAGIC = 2
+            ABYSSOPELAGIC = 3
+
+        class Squid(proto.Message):
+            zone = proto.Field(proto.ENUM, number=1, enum="Zone")
+
+    finally:
+        del sys.modules[__name__].__protobuf__
+
+    s = Squid(zone="ABYSSOPELAGIC")
+    assert s.zone == Zone.ABYSSOPELAGIC

--- a/tests/test_fields_enum.py
+++ b/tests/test_fields_enum.py
@@ -17,14 +17,14 @@ import sys
 
 
 def test_outer_enum_init():
+    class Foo(proto.Message):
+        color = proto.Field(proto.ENUM, number=1, enum="Color")
+
     class Color(proto.Enum):
         COLOR_UNSPECIFIED = 0
         RED = 1
         GREEN = 2
         BLUE = 3
-
-    class Foo(proto.Message):
-        color = proto.Field(Color, number=1)
 
     foo = Foo(color=Color.RED)
     assert foo.color == Color.RED
@@ -35,14 +35,14 @@ def test_outer_enum_init():
 
 
 def test_outer_enum_init_int():
+    class Foo(proto.Message):
+        color = proto.Field(proto.ENUM, number=1, enum="Color")
+
     class Color(proto.Enum):
         COLOR_UNSPECIFIED = 0
         RED = 1
         GREEN = 2
         BLUE = 3
-
-    class Foo(proto.Message):
-        color = proto.Field(Color, number=1)
 
     foo = Foo(color=1)
     assert foo.color == Color.RED
@@ -53,14 +53,14 @@ def test_outer_enum_init_int():
 
 
 def test_outer_enum_init_str():
+    class Foo(proto.Message):
+        color = proto.Field(proto.ENUM, number=1, enum="Color")
+
     class Color(proto.Enum):
         COLOR_UNSPECIFIED = 0
         RED = 1
         GREEN = 2
         BLUE = 3
-
-    class Foo(proto.Message):
-        color = proto.Field(Color, number=1)
 
     foo = Foo(color="RED")
     assert foo.color == Color.RED
@@ -71,14 +71,14 @@ def test_outer_enum_init_str():
 
 
 def test_outer_enum_init_dict():
+    class Foo(proto.Message):
+        color = proto.Field(proto.ENUM, number=1, enum="Color")
+
     class Color(proto.Enum):
         COLOR_UNSPECIFIED = 0
         RED = 1
         GREEN = 2
         BLUE = 3
-
-    class Foo(proto.Message):
-        color = proto.Field(Color, number=1)
 
     foo = Foo({"color": 1})
     assert foo.color == Color.RED
@@ -89,14 +89,14 @@ def test_outer_enum_init_dict():
 
 
 def test_outer_enum_init_dict_str():
+    class Foo(proto.Message):
+        color = proto.Field(proto.ENUM, number=1, enum="Color")
+
     class Color(proto.Enum):
         COLOR_UNSPECIFIED = 0
         RED = 1
         GREEN = 2
         BLUE = 3
-
-    class Foo(proto.Message):
-        color = proto.Field(Color, number=1)
 
     foo = Foo({"color": "BLUE"})
     assert foo.color == Color.BLUE
@@ -107,14 +107,14 @@ def test_outer_enum_init_dict_str():
 
 
 def test_outer_enum_init_pb2():
+    class Foo(proto.Message):
+        color = proto.Field(proto.ENUM, number=1, enum="Color")
+
     class Color(proto.Enum):
         COLOR_UNSPECIFIED = 0
         RED = 1
         GREEN = 2
         BLUE = 3
-
-    class Foo(proto.Message):
-        color = proto.Field(proto.ENUM, number=1, enum=Color)
 
     foo = Foo(Foo.pb()(color=Color.RED))
     assert foo.color == Color.RED
@@ -125,14 +125,14 @@ def test_outer_enum_init_pb2():
 
 
 def test_outer_enum_unset():
+    class Foo(proto.Message):
+        color = proto.Field(proto.ENUM, number=1, enum="Color")
+
     class Color(proto.Enum):
         COLOR_UNSPECIFIED = 0
         RED = 1
         GREEN = 2
         BLUE = 3
-
-    class Foo(proto.Message):
-        color = proto.Field(proto.ENUM, number=1, enum=Color)
 
     foo = Foo()
     assert foo.color == Color.COLOR_UNSPECIFIED
@@ -144,14 +144,14 @@ def test_outer_enum_unset():
 
 
 def test_outer_enum_write():
+    class Foo(proto.Message):
+        color = proto.Field(proto.ENUM, number=1, enum="Color")
+
     class Color(proto.Enum):
         COLOR_UNSPECIFIED = 0
         RED = 1
         GREEN = 2
         BLUE = 3
-
-    class Foo(proto.Message):
-        color = proto.Field(proto.ENUM, number=1, enum=Color)
 
     foo = Foo()
     foo.color = Color.GREEN
@@ -162,14 +162,14 @@ def test_outer_enum_write():
 
 
 def test_outer_enum_write_int():
+    class Foo(proto.Message):
+        color = proto.Field(proto.ENUM, number=1, enum="Color")
+
     class Color(proto.Enum):
         COLOR_UNSPECIFIED = 0
         RED = 1
         GREEN = 2
         BLUE = 3
-
-    class Foo(proto.Message):
-        color = proto.Field(proto.ENUM, number=1, enum=Color)
 
     foo = Foo()
     foo.color = 3
@@ -181,14 +181,14 @@ def test_outer_enum_write_int():
 
 
 def test_outer_enum_write_str():
+    class Foo(proto.Message):
+        color = proto.Field(proto.ENUM, number=1, enum="Color")
+
     class Color(proto.Enum):
         COLOR_UNSPECIFIED = 0
         RED = 1
         GREEN = 2
         BLUE = 3
-
-    class Foo(proto.Message):
-        color = proto.Field(Color, number=1)
 
     foo = Foo()
     foo.color = "BLUE"
@@ -207,7 +207,7 @@ def test_inner_enum_init():
             GREEN = 2
             BLUE = 3
 
-        color = proto.Field(proto.ENUM, number=1, enum=Color)
+        color = proto.Field(Color, number=1)
 
     foo = Foo(color=Foo.Color.RED)
     assert foo.color == Foo.Color.RED
@@ -236,14 +236,14 @@ def test_inner_enum_write():
 
 
 def test_enum_del():
+    class Foo(proto.Message):
+        color = proto.Field(proto.ENUM, number=1, enum="Color")
+
     class Color(proto.Enum):
         COLOR_UNSPECIFIED = 0
         RED = 1
         GREEN = 2
         BLUE = 3
-
-    class Foo(proto.Message):
-        color = proto.Field(Color, number=1)
 
     foo = Foo(color=Color.BLUE)
     del foo.color
@@ -255,29 +255,7 @@ def test_enum_del():
     assert Foo.pb(foo).color == 0
 
 
-class Zone(proto.Enum):
-    EPIPELAGIC = 0
-    MESOPELAGIC = 1
-    ABYSSOPELAGIC = 2
-    HADOPELAGIC = 3
-
-
-def test_enum_outest():
-    z = Zone(value=Zone.MESOPELAGIC)
-
-    assert z == Zone.MESOPELAGIC
-
-
 def test_nested_enum_from_string():
-    class Zone(proto.Enum):
-        EPIPELAGIC = 0
-        MESOPELAGIC = 1
-        BATHYPELAGIC = 2
-        ABYSSOPELAGIC = 3
-
-    class Squid(proto.Message):
-        zone = proto.Field(Zone, number=1)
-
     class Trawl(proto.Message):
         # Note: this indirection with the nested field
         # is necessary to trigger the exception for testing.
@@ -287,21 +265,30 @@ def test_nested_enum_from_string():
         # enum field kwarg passed as a string is also handled correctly, i.e.
         # s = Squid(zone="ABYSSOPELAGIC")
         # does NOT raise an exception.
-        squids = proto.RepeatedField(Squid, number=1)
+        squids = proto.RepeatedField("Squid", number=1)
 
-    t = Trawl(squids=[{"zone": "MESOPELAGIC"}])
-    assert t.squids[0] == Squid(zone=Zone.MESOPELAGIC)
+    class Squid(proto.Message):
+        zone = proto.Field(proto.ENUM, number=1, enum="Zone")
 
-
-def test_enum_field_by_string():
     class Zone(proto.Enum):
         EPIPELAGIC = 0
         MESOPELAGIC = 1
         BATHYPELAGIC = 2
         ABYSSOPELAGIC = 3
 
+    t = Trawl(squids=[{"zone": "MESOPELAGIC"}])
+    assert t.squids[0] == Squid(zone=Zone.MESOPELAGIC)
+
+
+def test_enum_field_by_string():
     class Squid(proto.Message):
         zone = proto.Field(proto.ENUM, number=1, enum="Zone")
+
+    class Zone(proto.Enum):
+        EPIPELAGIC = 0
+        MESOPELAGIC = 1
+        BATHYPELAGIC = 2
+        ABYSSOPELAGIC = 3
 
     s = Squid(zone=Zone.BATHYPELAGIC)
     assert s.zone == Zone.BATHYPELAGIC
@@ -311,17 +298,33 @@ def test_enum_field_by_string_with_package():
     sys.modules[__name__].__protobuf__ = proto.module(package="mollusca.cephalopoda")
     try:
 
+        class Octopus(proto.Message):
+            zone = proto.Field(proto.ENUM, number=1, enum="mollusca.cephalopoda.Zone")
+
         class Zone(proto.Enum):
             EPIPELAGIC = 0
             MESOPELAGIC = 1
             BATHYPELAGIC = 2
             ABYSSOPELAGIC = 3
 
-        class Squid(proto.Message):
-            zone = proto.Field(proto.ENUM, number=1, enum="Zone")
-
     finally:
         del sys.modules[__name__].__protobuf__
 
-    s = Squid(zone="ABYSSOPELAGIC")
-    assert s.zone == Zone.ABYSSOPELAGIC
+    o = Octopus(zone="MESOPELAGIC")
+    assert o.zone == Zone.MESOPELAGIC
+
+
+def test_enums_in_different_files():
+    import mollusc
+    import zone
+
+    m = mollusc.Mollusc(zone="BATHYPELAGIC")
+
+    assert m.zone == zone.Zone.BATHYPELAGIC
+
+
+def test_enums_in_one_file():
+    import clam
+
+    c = clam.Clam(species=clam.Species.DURASA)
+    assert c.species == clam.Species.DURASA

--- a/tests/test_fields_enum.py
+++ b/tests/test_fields_enum.py
@@ -269,7 +269,6 @@ def test_enum_outest():
 
 
 def test_nested_enum_from_string():
-
     class Zone(proto.Enum):
         EPIPELAGIC = 0
         MESOPELAGIC = 1
@@ -284,7 +283,7 @@ def test_nested_enum_from_string():
         # is necessary to trigger the exception for testing.
         # Setting the field in an existing message accepts strings AND
         # checks for valid variants.
-        # Similarly, constructing a message directly with a top level 
+        # Similarly, constructing a message directly with a top level
         # enum field kwarg passed as a string is also handled correctly, i.e.
         # s = Squid(zone="ABYSSOPELAGIC")
         # does NOT raise an exception.
@@ -311,6 +310,7 @@ def test_enum_field_by_string():
 def test_enum_field_by_string_with_package():
     sys.modules[__name__].__protobuf__ = proto.module(package="mollusca.cephalopoda")
     try:
+
         class Zone(proto.Enum):
             EPIPELAGIC = 0
             MESOPELAGIC = 1

--- a/tests/test_file_info_salting.py
+++ b/tests/test_file_info_salting.py
@@ -40,6 +40,7 @@ def sample_file_info(name):
             messages=collections.OrderedDict(),
             name=filename,
             nested={},
+            nested_enum={},
         ),
     )
 

--- a/tests/test_file_info_salting_with_manifest.py
+++ b/tests/test_file_info_salting_with_manifest.py
@@ -55,6 +55,7 @@ def sample_file_info(name):
             messages=collections.OrderedDict(),
             name=filename,
             nested={},
+            nested_enum={},
         ),
     )
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -50,3 +50,48 @@ def test_message_json_round_trip():
     s2 = Squid.from_json(json)
 
     assert s == s2
+
+
+def test_json_stringy_enums():
+    class Squid(proto.Message):
+        zone = proto.Field(proto.ENUM, number=1, enum="Zone")
+
+    class Zone(proto.Enum):
+        EPIPELAGIC = 0
+        MESOPELAGIC = 1
+        BATHYPELAGIC = 2
+        ABYSSOPELAGIC = 3
+
+    s1 = Squid(zone=Zone.MESOPELAGIC)
+    json = (
+        Squid.to_json(s1, use_integers_for_enums=False)
+        .replace(" ", "")
+        .replace("\n", "")
+    )
+    assert json == '{"zone":"MESOPELAGIC"}'
+
+    s2 = Squid.from_json(json)
+    assert s2.zone == s1.zone
+
+
+def test_json_default_enums():
+    class Squid(proto.Message):
+        zone = proto.Field(proto.ENUM, number=1, enum="Zone")
+
+    class Zone(proto.Enum):
+        EPIPELAGIC = 0
+        MESOPELAGIC = 1
+        BATHYPELAGIC = 2
+        ABYSSOPELAGIC = 3
+
+    s = Squid()
+    assert s.zone == Zone.EPIPELAGIC
+    json1 = Squid.to_json(s).replace(" ", "").replace("\n", "")
+    assert json1 == '{"zone":0}'
+
+    json2 = (
+        Squid.to_json(s, use_integers_for_enums=False)
+        .replace(" ", "")
+        .replace("\n", "")
+    )
+    assert json2 == '{"zone":"EPIPELAGIC"}'

--- a/tests/test_marshal_types_enum.py
+++ b/tests/test_marshal_types_enum.py
@@ -18,6 +18,8 @@ import warnings
 import proto
 from proto.marshal.rules.enums import EnumRule
 
+__protobuf__ = proto.module(package="test.marshal.enum")
+
 
 def test_to_proto():
     class Foo(proto.Enum):

--- a/tests/zone.py
+++ b/tests/zone.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2020  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import proto
+
+
+__protobuf__ = proto.module(package="ocean.zone.v1", manifest={"Zone",},)
+
+
+class Zone(proto.Enum):
+    EPIPELAGIC = 0
+    MESOPELAGIC = 1
+    BATHYPELAGIC = 2
+    ABYSSOPELAGIC = 3


### PR DESCRIPTION
For protobuf messages that contain enum fields, it is now possible to
specify that enum variants should be serialized as names and not as integers.

E.g.
```python
json_str = MyMessage.to_json(my_message, use_integers_for_enums=False)
```

Similarly, serialization from json that uses this convention is now supported.

This is useful for interoperation with other data sources that do use
strings to define enum variants in json serialization; and for
debugging, where visually inspecting data structures can be helpful,
and variant names are more informative than numerical values.

Re-addition of #107 with correct support for nested enum definitions
this time.