### PR TITLE
docs: update README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,4 +30,3 @@ Documentation
   :target: https://circleci.com/gh/googleapis/proto-plus-python
 .. |codecov| image:: https://codecov.io/gh/googleapis/proto-plus-python/graph/badge.svg
   :target: https://codecov.io/gh/googleapis/proto-plus-python
-


### PR DESCRIPTION
Take 3 of releasing 1.9.1. The GitHub automation folks kindly told me that I need to use something that's not `chore:` so release please won't skip it.

Release-As: 1.9.1