### PR TITLE
fix: fix regex match for release tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ workflows:
       - style-check:
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+$/
+              only: /^v\d+\.\d+\.\d+.*/
       - publish_package:
           requires:
             - style-check
@@ -15,7 +15,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v\d+\.\d+\.\d+\.*$/
+              only: /^v\d+\.\d+\.\d+.*/
       - unit-3.5:
           filters:
             tags:


### PR DESCRIPTION
Allow matches for pre-releases like 1.0.0-dev1.

Release-As: 1.10.0-dev3