### PR TITLE
feat: nullable ListValue and Struct fields

### DIFF
--- a/docs/marshal.rst
+++ b/docs/marshal.rst
@@ -23,9 +23,9 @@ Protocol buffer type                Python type             Nullable
 ``google.protobuf.FloatValue``      ``float``                    Yes
 ``google.protobuf.Int32Value``      ``int``                      Yes
 ``google.protobuf.Int64Value``      ``int``                      Yes
-``google.protobuf.ListValue``       ``MutableSequence``            –
+``google.protobuf.ListValue``       ``MutableSequence``          Yes
 ``google.protobuf.StringValue``     ``str``                      Yes
-``google.protobuf.Struct``          ``MutableMapping``             –
+``google.protobuf.Struct``          ``MutableMapping``           Yes
 ``google.protobuf.Timestamp``       ``datetime.datetime``        Yes
 ``google.protobuf.UInt32Value``     ``int``                      Yes
 ``google.protobuf.UInt64Value``     ``int``                      Yes

--- a/proto/marshal/rules/struct.py
+++ b/proto/marshal/rules/struct.py
@@ -110,7 +110,9 @@ class StructRule:
 
     def to_python(self, value, *, absent: bool = None):
         """Coerce the given value to a Python mapping."""
-        return maps.MapComposite(value.fields, marshal=self._marshal)
+        return (
+            None if absent else maps.MapComposite(value.fields, marshal=self._marshal)
+        )
 
     def to_proto(self, value) -> struct_pb2.Struct:
         # We got a proto, or else something we sent originally.

--- a/proto/marshal/rules/struct.py
+++ b/proto/marshal/rules/struct.py
@@ -82,7 +82,11 @@ class ListValueRule:
 
     def to_python(self, value, *, absent: bool = None):
         """Coerce the given value to a Python sequence."""
-        return repeated.RepeatedComposite(value.values, marshal=self._marshal)
+        return (
+            None
+            if absent
+            else repeated.RepeatedComposite(value.values, marshal=self._marshal)
+        )
 
     def to_proto(self, value) -> struct_pb2.ListValue:
         # We got a proto, or else something we sent originally.

--- a/tests/test_marshal_types_struct.py
+++ b/tests/test_marshal_types_struct.py
@@ -72,6 +72,14 @@ def test_value_lists_null():
     assert foo.value is None
 
 
+def test_value_struct_null():
+    class Foo(proto.Message):
+        value = proto.Field(struct_pb2.Struct, number=1)
+
+    foo = Foo()
+    assert foo.value is None
+
+
 def test_value_lists_rmw():
     class Foo(proto.Message):
         value = proto.Field(struct_pb2.Value, number=1)

--- a/tests/test_marshal_types_struct.py
+++ b/tests/test_marshal_types_struct.py
@@ -64,6 +64,14 @@ def test_value_lists_read():
     assert foo.value == ["3", None, "foo", True]
 
 
+def test_value_lists_null():
+    class Foo(proto.Message):
+        value = proto.Field(struct_pb2.ListValue, number=1)
+
+    foo = Foo()
+    assert foo.value is None
+
+
 def test_value_lists_rmw():
     class Foo(proto.Message):
         value = proto.Field(struct_pb2.Value, number=1)


### PR DESCRIPTION
Assume a message type with a ListValue or Struct field.
If a message instance is created with no value passed in for that field,
 the field is None when accessed via Python.