### PR TITLE
docs: link to pypi protobuf package

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,9 @@ Install this library using ``pip``:
     $ pip install proto-plus
 
 This library carries a dependency on the official implementation
-(``protobuf``), which may install a C component.
+(protobuf_), which may install a C component.
+
+.. _protobuf: https://pypi.org/project/protobuf/
 
 
 Table of Contents


### PR DESCRIPTION
Release-As: 1.10.0

Creating a release for the stringy enum change previously released in 1.10.0.dev2. #118

The tests for the following libraries are green when run with the current dev release. (Most of these libraries were chosen because they previously had failing tests). 

- https://github.com/googleapis/python-firestore/pull/193
- https://github.com/googleapis/python-automl/pull/77
- https://github.com/googleapis/python-asset/pull/90
- https://github.com/googleapis/python-dlp/pull/56

The Spanner folks also reported the dev release resolved the stringy enums issue without creating new test failures.