### PR TITLE
fix: accessing an unset struct_pb2.Value field does not raise

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import imp
+import importlib
 from unittest import mock
 
 from google.protobuf import descriptor_pool
@@ -76,11 +76,11 @@ def pytest_runtest_setup(item):
     # If the marshal had previously registered the old message classes,
     # then reload the appropriate modules so the marshal is using the new ones.
     if "wrappers_pb2" in reloaded:
-        imp.reload(rules.wrappers)
+        importlib.reload(rules.wrappers)
     if "struct_pb2" in reloaded:
-        imp.reload(rules.struct)
+        importlib.reload(rules.struct)
     if reloaded.intersection({"timestamp_pb2", "duration_pb2"}):
-        imp.reload(rules.dates)
+        importlib.reload(rules.dates)
 
 
 def pytest_runtest_teardown(item):

--- a/tests/test_marshal_types_struct.py
+++ b/tests/test_marshal_types_struct.py
@@ -30,6 +30,13 @@ def test_value_primitives_read():
     assert Foo(value=True).value is True
 
 
+def test_value_absent():
+    class Foo(proto.Message):
+        value = proto.Field(struct_pb2.Value, number=1)
+
+    assert Foo().value is None
+
+
 def test_value_primitives_rmw():
     class Foo(proto.Message):
         value = proto.Field(struct_pb2.Value, number=1)
@@ -158,7 +165,7 @@ def test_value_unset():
         value = proto.Field(struct_pb2.Value, number=1)
 
     foo = Foo()
-    assert not hasattr(foo, "value")
+    assert "value" not in foo
 
 
 def test_list_value_read():


### PR DESCRIPTION
```python
class Foo(proto.Message):
    value = proto.Field(struct_pb2.Value, number=1)

f = Foo()
assert f.value is None          # This should not raise an exception.
assert "value" not in f         # The attribute has _not_ been set.
f.value = None
assert f.value is None
assert "value" in f             # The attribute _has_ been set.
```
None of the above should raise an exception.

Closes #139 