### PR TITLE
fix: add LICENSE and tests to package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include README.rst LICENSE
+recursive-include tests *
+global-exclude *.py[co]
+global-exclude __pycache__


### PR DESCRIPTION
Closes #143 and #141 

Adds [MANIFEST.in](https://packaging.python.org/guides/using-manifest-in/) so the license and tests are included in the published package.