### PR TITLE
docs: explain how to use repeated struct.Value

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@
 import os
 import sys
 
+import pkg_resources
 sys.path.insert(0, os.path.abspath(".."))
 
 
@@ -22,12 +23,9 @@ sys.path.insert(0, os.path.abspath(".."))
 
 project = "Proto Plus for Python"
 copyright = "2018, Google LLC"
-author = "Luke Sneeringer"
+author = "Google LLC"
 
-# The short X.Y version
-version = "0.1.0"
-# The full version, including alpha/beta/rc tags
-release = "0.1.0"
+version = pkg_resources.get_distribution("proto-plus").version
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,8 @@ import os
 import sys
 
 import pkg_resources
+
+
 sys.path.insert(0, os.path.abspath(".."))
 
 

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -56,6 +56,36 @@ Declare them in Python using the :class:`~.RepeatedField` class:
         publisher = proto.Field(proto.STRING, number=2)
 
 
+.. note::
+
+    Elements **must** be appended individually for repeated fields of `struct.Value`.
+
+    .. code-block:: python
+
+        class Row(proto.Message):
+            values = proto.RepeatedField(proto.MESSAGE, number=1, message=struct.Value,)
+
+        >>> row = Row()
+        >>> values = [struct_pb2.Value(string_value="hello")]
+        >>> for v in values:
+        >>>    row.values.append(v)
+
+    Direct assignment will result in an error.
+
+    .. code-block:: python
+
+        class Row(proto.Message):
+            values = proto.RepeatedField(proto.MESSAGE, number=1, message=struct.Value,)
+
+        >>> row = Row()
+        >>> row.values = [struct_pb2.Value(string_value="hello")]
+        Traceback (most recent call last):
+        File "<stdin>", line 1, in <module>
+        File "/usr/local/google/home/busunkim/github/python-automl/.nox/unit-3-8/lib/python3.8/site-packages/proto/message.py", line 543, in __setattr__
+            self._pb.MergeFrom(self._meta.pb(**{key: pb_value}))
+        TypeError: Value must be iterable
+
+
 Map fields
 ----------
 
@@ -168,3 +198,6 @@ one-variant ``oneof``. See the protocolbuffers documentation_ for more
 information.
 
 .. _documentation: https://github.com/protocolbuffers/protobuf/blob/v3.12.0/docs/field_presence.md
+
+
+

--- a/docs/reference/datetime_helpers.rst
+++ b/docs/reference/datetime_helpers.rst
@@ -1,0 +1,5 @@
+Datetime Helpers
+----------------
+
+.. automodule:: proto.datetime_helpers
+    :members:

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -4,15 +4,16 @@ Reference
 Below is a reference for the major classes and functions within this
 module.
 
-It is split into two main sections:
-
 - The :doc:`message` section (which uses the ``message`` and ``fields``
   modules) handles constructing messages.
 - The :doc:`marshal` module handles translating between internal protocol
   buffer instances and idiomatic equivalents.
+- The :doc:`datetime_helpers` has datetime related helpers to maintain
+  nanosecond precision.
 
 .. toctree::
     :maxdepth: 2
 
     message
     marshal
+    datetime_helpers

--- a/docs/reference/message.rst
+++ b/docs/reference/message.rst
@@ -5,8 +5,11 @@ Message and Field
     :members:
 
     .. automethod:: pb
+    .. automethod:: wrap
     .. automethod:: serialize
     .. automethod:: deserialize
+    .. automethod:: to_json
+    .. automethod:: from_json
 
 
 .. automodule:: proto.fields


### PR DESCRIPTION
Closes #104 

* Explain how to set fields of repeated `struct.Value`
* Add `datetime_helpers` to reference docs
* Add `wrap`, `to_json`, and `from_json` to reference docs
* Fetch correct package version for `docs/conf.py`