### PR TITLE
feat: provide a to_dict method

### DIFF
--- a/docs/messages.rst
+++ b/docs/messages.rst
@@ -165,3 +165,13 @@ via the :meth:`~.Message.to_json` and :meth:`~.Message.from_json` methods.
 
     new_song = Song.from_json(json)
 
+Similarly, messages can be converted into dictionaries via the
+:meth:`~.Message.to_dict` helper method.
+There is no :meth:`~.Message.from_dict` method because the Message constructor
+already allows construction from mapping types.
+
+.. code-block:: python
+
+   song_dict = Song.to_dict(song)
+
+   new_song = Song(song_dict)

--- a/docs/reference/message.rst
+++ b/docs/reference/message.rst
@@ -10,6 +10,7 @@ Message and Field
     .. automethod:: deserialize
     .. automethod:: to_json
     .. automethod:: from_json
+    .. automethod:: to_dict
 
 
 .. automodule:: proto.fields

--- a/noxfile.py
+++ b/noxfile.py
@@ -48,7 +48,7 @@ def unitcpp(session):
     return unit(session, proto="cpp")
 
 
-@nox.session(python="3.6")
+@nox.session(python="3.7")
 def docs(session):
     """Build the docs."""
 


### PR DESCRIPTION
Parallels the `to_json` method.
Also adds options to ignore unknown fields during deserializtion.

Closes #153 
Closes #151 