### PR TITLE
fix: adding enums to a repeated field does not raise a TypeError

### DIFF
--- a/proto/marshal/collections/repeated.py
+++ b/proto/marshal/collections/repeated.py
@@ -174,5 +174,5 @@ class RepeatedComposite(Repeated):
 
     def insert(self, index: int, value):
         """Insert ``value`` in the sequence before ``index``."""
-        pb_value = self._marshal.to_proto(self._pb_type, value, strict=True)
+        pb_value = self._marshal.to_proto(self._pb_type, value)
         self.pb.insert(index, pb_value)

--- a/tests/test_marshal_strict.py
+++ b/tests/test_marshal_strict.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2021  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import proto
+from proto.marshal.marshal import BaseMarshal
+import pytest
+
+
+def test_strict_to_proto():
+    m = BaseMarshal()
+
+    with pytest.raises(TypeError):
+        m.to_proto(dict, None, strict=True)

--- a/tests/test_marshal_types_enum.py
+++ b/tests/test_marshal_types_enum.py
@@ -58,3 +58,44 @@ def test_to_python_unknown_value():
     with mock.patch.object(warnings, "warn") as warn:
         assert enum_rule.to_python(4) == 4
         warn.assert_called_once_with("Unrecognized Foo enum value: 4")
+
+
+def test_enum_append():
+    class Bivalve(proto.Enum):
+        CLAM = 0
+        OYSTER = 1
+
+    class MolluscContainer(proto.Message):
+        bivalves = proto.RepeatedField(
+            proto.ENUM,
+            number=1,
+            enum=Bivalve,
+        )
+
+    mc = MolluscContainer()
+    clam = Bivalve.CLAM
+    mc.bivalves.append(clam)
+    mc.bivalves.append(1)
+
+    assert mc.bivalves == [clam, Bivalve.OYSTER]
+
+
+def test_enum_map_insert():
+    class Bivalve(proto.Enum):
+        CLAM = 0
+        OYSTER = 1
+
+    class MolluscContainer(proto.Message):
+        bivalves = proto.MapField(
+            proto.STRING,
+            proto.ENUM,
+            number=1,
+            enum=Bivalve,
+        )
+
+    mc = MolluscContainer()
+    clam = Bivalve.CLAM
+    mc.bivalves["clam"] = clam
+    mc.bivalves["oyster"] = 1
+
+    assert mc.bivalves == {"clam": clam, "oyster": Bivalve.OYSTER}

--- a/tests/test_marshal_types_enum.py
+++ b/tests/test_marshal_types_enum.py
@@ -66,11 +66,7 @@ def test_enum_append():
         OYSTER = 1
 
     class MolluscContainer(proto.Message):
-        bivalves = proto.RepeatedField(
-            proto.ENUM,
-            number=1,
-            enum=Bivalve,
-        )
+        bivalves = proto.RepeatedField(proto.ENUM, number=1, enum=Bivalve,)
 
     mc = MolluscContainer()
     clam = Bivalve.CLAM
@@ -86,12 +82,7 @@ def test_enum_map_insert():
         OYSTER = 1
 
     class MolluscContainer(proto.Message):
-        bivalves = proto.MapField(
-            proto.STRING,
-            proto.ENUM,
-            number=1,
-            enum=Bivalve,
-        )
+        bivalves = proto.MapField(proto.STRING, proto.ENUM, number=1, enum=Bivalve,)
 
     mc = MolluscContainer()
     clam = Bivalve.CLAM


### PR DESCRIPTION
Fixes issue #201, where enums added to a repeated field triggered a
TypeError because they were coverted to integers during marshaling.