### PR TITLE
feat: allow_alias for enums

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -12,7 +12,7 @@ branchProtectionRules:
     - 'unit (3.7)'
     - 'unit (3.7, cpp)'
     - 'unit (3.8)'
-    - 'unit (3.9, cpp)'
+    # - 'unit (3.9, cpp)' # Don't have binary wheels for 3.9 cpp protobuf yet
     - 'unit (3.9)'
     - 'cla/google'
   requiredApprovingReviewCount: 1


### PR DESCRIPTION
Certain APIs, e.g. recommendationengine, have enums where variants are
aliased, i.e. different names map to the same integer value.

Allowing this behavior in proto plus for the cpp protobuf runtime
requires constructing and passing the correct options.