### PR TITLE
chore: use repository secrets for pypi upload

### DIFF
--- a/.github/workflows/pypi-upload.yaml
+++ b/.github/workflows/pypi-upload.yaml
@@ -7,7 +7,6 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: PyPI
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python


### PR DESCRIPTION
This is coupled with a behind the scenes change to the repository secrets.