### PR TITLE
Add arm64 support for PY3.6

### DIFF
--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -5,5 +5,5 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-protobuf==3.12.0
+protobuf==3.15.6
 google-api-core==1.22.2


### PR DESCRIPTION
The following files have been modified:
In **testing/constraints-3.6.txt:**
1. Upgraded **Protobuf** version from protobuf==3.12.0 to protobuf==3.15.6

Build with **python3.6** is using v3.12.0 of protobuf. Its wheel is not available for arm64, and source tar is also not present for v3.12.0 to build from source. So upgrading protobuf to recent version having source tar.