### PR TITLE
chore: prevent normalization of semver versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 import io
 import os
 
-from setuptools import find_packages, setup
+import setuptools
 
 version = "1.18.1"
 
@@ -24,14 +24,14 @@ PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(PACKAGE_ROOT, "README.rst")) as file_obj:
     README = file_obj.read()
 
-setup(
+setuptools.setup(
     name="proto-plus",
     version=setuptools.sic(version),
     license="Apache 2.0",
     author="Google LLC",
     author_email="googleapis-packages@google.com",
     url="https://github.com/googleapis/proto-plus-python.git",
-    packages=find_packages(exclude=["docs", "tests"]),
+    packages=setuptools.find_packages(exclude=["docs", "tests"]),
     description="Beautiful, Pythonic protocol buffers.",
     long_description=README,
     platforms="Posix; MacOS X",

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,21 @@ import os
 
 import setuptools
 
+# Disable version normalization performed by setuptools.setup()
+try:
+    # Try the approach of using sic(), added in setuptools 46.1.0
+    from setuptools import sic
+except ImportError:
+    # Try the approach of replacing packaging.version.Version
+    sic = lambda v: v
+    try:
+        # setuptools >=39.0.0 uses packaging from setuptools.extern
+        from setuptools.extern import packaging
+    except ImportError:
+        # setuptools <39.0.0 uses packaging from pkg_resources.extern
+        from pkg_resources.extern import packaging
+    packaging.version.Version = packaging.version.LegacyVersion
+
 version = "1.18.1"
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
@@ -26,7 +41,7 @@ with io.open(os.path.join(PACKAGE_ROOT, "README.rst")) as file_obj:
 
 setuptools.setup(
     name="proto-plus",
-    version=setuptools.sic(version),
+    version=sic(version),
     license="Apache 2.0",
     author="Google LLC",
     author_email="googleapis-packages@google.com",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with io.open(os.path.join(PACKAGE_ROOT, "README.rst")) as file_obj:
 
 setup(
     name="proto-plus",
-    version=version,
+    version=setuptools.sic(version),
     license="Apache 2.0",
     author="Google LLC",
     author_email="googleapis-packages@google.com",


### PR DESCRIPTION
When there is a patch version added to semver versioning, setuptools.setup(version) will normalize the versioning from -patch to .patch which is not correct SEMVER versioning. The added feature with setuptools.sic(version) will prevent this from happening.