### PR TITLE
[WIP] Protobuf Performance Refactor

### DIFF
--- a/proto/fields.py
+++ b/proto/fields.py
@@ -136,10 +136,6 @@ class Field:
         return self.mcls_data["package"]
 
     @property
-    def inner_pb_type(self):
-        return None
-
-    @property
     def pb_type(self):
         """Return the composite type of the field, or None for primitives."""
         # For enums, return the Python enum.
@@ -263,10 +259,6 @@ class MapField(Field):
     def __init__(self, key_type, value_type, *, number: int, message=None, enum=None):
         super().__init__(value_type, number=number, message=message, enum=enum)
         self.map_key_type = key_type
-
-    @property
-    def inner_pb_type(self):
-        return
 
 
 class _FieldDescriptor:

--- a/proto/fields.py
+++ b/proto/fields.py
@@ -12,11 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 from enum import EnumMeta
+from re import L
+from proto.marshal.rules import wrappers
+from proto.datetime_helpers import DatetimeWithNanoseconds
+from proto.marshal.rules.dates import DurationRule
+from typing import Any, Callable, Optional, Union
 
 from google.protobuf import descriptor_pb2
+from google.protobuf import duration_pb2
+from google.protobuf import struct_pb2
+from google.protobuf import timestamp_pb2
+from google.protobuf import wrappers_pb2
 from google.protobuf.internal.enum_type_wrapper import EnumTypeWrapper
 
+import proto
 from proto.primitives import ProtoType
 
 
@@ -125,6 +136,10 @@ class Field:
         return self.mcls_data["package"]
 
     @property
+    def inner_pb_type(self):
+        return None
+
+    @property
     def pb_type(self):
         """Return the composite type of the field, or None for primitives."""
         # For enums, return the Python enum.
@@ -140,6 +155,86 @@ class Field:
             return self.message.pb()
         return self.message
 
+    @property
+    def can_get_natively(self) -> bool:
+        if self.proto_type == ProtoType.MESSAGE and self.message == struct_pb2.Value:
+            return False
+        return True
+
+    def can_set_natively(self, val: Any) -> bool:
+        if self.proto_type == ProtoType.MESSAGE and self.message == struct_pb2.Value:
+            return False
+        return True
+        # return self.pb_type is None and not self.repeated
+
+    def contribute_to_class(self, cls, name: str):
+        set_coercion = None
+        if self.proto_type == ProtoType.STRING:
+            set_coercion = self._bytes_to_str
+        if self.pb_type == timestamp_pb2.Timestamp:
+            set_coercion = self._timestamp_to_datetime
+        if self.proto_type == ProtoType.MESSAGE and self.message == duration_pb2.Duration:
+            set_coercion = self._duration_to_timedelta
+        if self.proto_type == ProtoType.MESSAGE and self.message == wrappers_pb2.BoolValue:
+            set_coercion = self._bool_value_to_bool
+        if self.enum:
+            set_coercion = self._literal_to_enum
+        setattr(cls, name, self._get_field_descriptor_class()(name, cls=cls, set_coercion=set_coercion))
+
+    @staticmethod
+    def _get_field_descriptor_class():
+        return _FieldDescriptor
+
+    @property
+    def reverse_enum_map(self):
+        if not self.enum:
+            return None
+        if not getattr(self, '_reverse_enum_map', None):
+            self._reverse_enum_map = {e.value: e for e in self.enum}
+        return self._reverse_enum_map
+
+    @property
+    def reverse_enum_names_map(self):
+        if not self.enum:
+            return None
+        if not getattr(self, '_reverse_enum_names_map', None):
+            self._reverse_enum_names_map = {e.name: e for e in self.enum}
+        return self._reverse_enum_names_map
+
+    def _literal_to_enum(self, val: Any):
+        if isinstance(val, self.enum):
+            return val
+        return (
+            self.reverse_enum_map.get(val, None) or
+            self.reverse_enum_names_map.get(val, None)
+        )
+
+    @staticmethod
+    def _bytes_to_str(val: Union[bytes, str]) -> str:
+        if type(val) == bytes:
+            val = val.decode('utf-8')
+        return val
+
+    @staticmethod
+    def _timestamp_to_datetime(val: Union[timestamp_pb2.Timestamp, datetime.datetime]) -> datetime.datetime:
+        if type(val) == timestamp_pb2.Timestamp:
+            val = DatetimeWithNanoseconds.from_timestamp_pb(val)
+        return val
+
+    @staticmethod
+    def _duration_to_timedelta(val: Union[duration_pb2.Duration, datetime.timedelta]) -> datetime.datetime:
+        if type(val) == duration_pb2.Duration:
+            val = DurationRule().to_python(val)
+        return val
+
+    @staticmethod
+    def _bool_value_to_bool(val: Union[wrappers_pb2.BoolValue, bool]) -> Optional[bool]:
+        if val is None:
+            return None
+        if type(val) == wrappers_pb2.BoolValue:
+            val = val.value
+        return val
+
 
 class RepeatedField(Field):
     """A representation of a repeated field in protocol buffers."""
@@ -153,6 +248,114 @@ class MapField(Field):
     def __init__(self, key_type, value_type, *, number: int, message=None, enum=None):
         super().__init__(value_type, number=number, message=message, enum=enum)
         self.map_key_type = key_type
+
+    @property
+    def inner_pb_type(self):
+        return
+
+
+class _FieldDescriptor:
+    def __init__(self, name: str, *, cls, set_coercion: Optional[Callable] = None):
+        # something like "id". required whenever reach back to the pb2 object.
+        self.original_name = name
+        # something like "_cached_id"
+        self.instance_attr_name = f'_cached_fields__{name}'
+
+        # simple types coercion for setting attributes (for example, bytes -> str)
+        self._set_coercion = set_coercion or _FieldDescriptor._noop
+        self.cls = cls
+
+    @property
+    def field(self):
+        return self.cls._meta.fields[self.original_name]
+
+    def _hydrate_dicts(self, value: Any, instance):
+        if not isinstance(value, dict):
+            return value
+
+        if self.field.proto_type == proto.MESSAGE:
+            _pb = self.field.message._meta.pb(**value)
+            value = self.field.message.wrap(_pb)
+
+        return value
+
+    def _clear_oneofs(self, instance):
+        if not self.field.oneof:
+            return
+
+        for field_name, field in self.cls._meta.fields.items():
+            # Don't clear this field
+            if field_name == self.original_name:
+                continue
+
+            # Don't clear other fields with different oneof values, or with
+            # no such values at all
+            if field.oneof != self.field.oneof:
+                continue
+
+            delattr(instance, field_name)
+
+    def __set__(self, instance, value):
+        value = self._set_coercion(value)
+        value = self._hydrate_dicts(value, instance)
+
+        always_commit: bool = getattr(instance, '_always_commit', False)
+        if always_commit or not self.field.can_set_natively(value):  #  or self.field.pb_type is not None or self.field.repeated:
+            # MapFields have a unique requirement to always eagerly commit their
+            # writes, as the MapComposite implementation does not used long-lived
+            # proto-plus types, and thus any information about dirty fields is
+            # discarded and leads to irrepairable de-sync between proto-plus and
+            # protobuf.
+            pb_value = instance._meta.marshal.to_proto(self.field.pb_type, value)
+            _pb = instance._meta.pb(**{self.original_name: pb_value})
+            instance._pb.ClearField(self.original_name)
+            instance._pb.MergeFrom(_pb)
+        else:
+
+            if value is None:
+                self.__delete__(instance)
+                instance._pb.MergeFrom(instance._meta._pb(**{self.original_name: None}))
+                return
+
+            instance._meta.marshal.validate_primitives(self.field, value)
+            instance._mark_pb_stale(self.original_name)
+
+        setattr(instance, self.instance_attr_name, value)
+        self._clear_oneofs(instance)
+
+    def __get__(self, instance: 'proto.Message', owner):  # type: ignore
+        # If `instance` is None, then we are accessing this field directly
+        # off the class itself instead of off an instance.
+        if instance is None:
+            return self.original_name
+
+        value = getattr(instance, self.instance_attr_name, None)
+        if self.field.can_get_natively and value is not None:
+            return value
+        else:
+            # For the most part, only primitive values can be returned natively, meaning
+            # this is either a Message itself, in which case, since we're dealing with the
+            # underlying pb object, we need to sync all deferred fields.
+            # This is functionally a no-op if no fields have been deferred.
+            if hasattr(value, '_update_pb'):
+                value._update_pb()
+
+        pb_value = getattr(instance._pb, self.original_name, None)
+        value = instance._meta.marshal.to_python(self.field.pb_type, pb_value, absent=self.original_name not in instance)
+
+        setattr(instance, self.instance_attr_name, value)
+        return value
+
+    def __delete__(self, instance):
+        if hasattr(instance, self.instance_attr_name):
+            delattr(instance, self.instance_attr_name)
+        instance._pb.ClearField(self.original_name)
+        if self.original_name in getattr(instance, '_stale_fields', []):
+            instance._stale_fields.remove(self.original_name)
+
+    @staticmethod
+    def _noop(val):
+        return val
 
 
 __all__ = (

--- a/proto/marshal/collections/maps.py
+++ b/proto/marshal/collections/maps.py
@@ -14,6 +14,7 @@
 
 import collections
 
+import proto
 from proto.utils import cached_property
 
 
@@ -25,10 +26,18 @@ class MapComposite(collections.abc.MutableMapping):
     """
 
     @cached_property
+    def entry_class(self):
+        return self.pb.GetEntryClass()
+
+    @cached_property
     def _pb_type(self):
         """Return the protocol buffer type for this sequence."""
         # Huzzah, another hack. Still less bad than RepeatedComposite.
-        return type(self.pb.GetEntryClass()().value)
+        return type(self.entry_class().value)
+
+    @cached_property
+    def _override_pb_type(self):
+        return getattr(self.entry_class._meta["fields"]["value"], "pb_override", None)
 
     def __init__(self, sequence, *, marshal):
         """Initialize a wrapper around a protobuf map.
@@ -54,7 +63,10 @@ class MapComposite(collections.abc.MutableMapping):
         # buffers will create the key if it does not exist.
         if key not in self:
             raise KeyError(key)
-        return self._marshal.to_python(self._pb_type, self.pb[key])
+        obj = self._marshal.to_python(self._pb_type, self.pb[key])
+        if isinstance(obj, proto.Message):
+            obj._always_commit = True
+        return obj
 
     def __setitem__(self, key, value):
         pb_value = self._marshal.to_proto(self._pb_type, value, strict=True)

--- a/proto/marshal/collections/maps.py
+++ b/proto/marshal/collections/maps.py
@@ -26,18 +26,10 @@ class MapComposite(collections.abc.MutableMapping):
     """
 
     @cached_property
-    def entry_class(self):
-        return self.pb.GetEntryClass()
-
-    @cached_property
     def _pb_type(self):
         """Return the protocol buffer type for this sequence."""
         # Huzzah, another hack. Still less bad than RepeatedComposite.
-        return type(self.entry_class().value)
-
-    @cached_property
-    def _override_pb_type(self):
-        return getattr(self.entry_class._meta["fields"]["value"], "pb_override", None)
+        return type(self.self.pb.GetEntryClass()().value)
 
     def __init__(self, sequence, *, marshal):
         """Initialize a wrapper around a protobuf map.

--- a/proto/marshal/collections/maps.py
+++ b/proto/marshal/collections/maps.py
@@ -29,7 +29,7 @@ class MapComposite(collections.abc.MutableMapping):
     def _pb_type(self):
         """Return the protocol buffer type for this sequence."""
         # Huzzah, another hack. Still less bad than RepeatedComposite.
-        return type(self.self.pb.GetEntryClass()().value)
+        return type(self.pb.GetEntryClass()().value)
 
     def __init__(self, sequence, *, marshal):
         """Initialize a wrapper around a protobuf map.

--- a/proto/marshal/marshal.py
+++ b/proto/marshal/marshal.py
@@ -136,6 +136,11 @@ class BaseMarshal:
         raise ValueError(f"Unacceptable value {type(primitive)} for type {proto_type}")
 
     def validate_primitives(self, field, primitive):
+        """Replicates validation logic when assigning values to proto.Field attributes
+        on instantiated proto.Message objects. This is required to recreate the immediacy
+        of ValueError and TypeError checks that the pb2 layer made, but which are now
+        deferred because syncing to the pb2 layer itself is often entirely deferred.
+        """
         proto_type = field.proto_type
         if field.repeated:
             if primitive and not isinstance(primitive, (list, Repeated, RepeatedComposite,)):
@@ -168,9 +173,9 @@ class BaseMarshal:
             self._throw_type_error(primitive)
         elif proto_type == proto.STRING and _type not in (str, bytes,):
             self._throw_type_error(primitive)
-        # elif proto_type == proto.MESSAGE:
-        #     # This is not a primitive!
-        #     self._throw_type_error(primitive)
+        elif proto_type == proto.MESSAGE:
+            # Do nothing - this is not a primitive
+            pass
         elif proto_type == proto.BYTES and _type != bytes:
             self._throw_type_error(primitive)
         elif proto_type == proto.UINT32:
@@ -178,9 +183,9 @@ class BaseMarshal:
                 self._throw_type_error(primitive)
             if primitive < 0 or primitive > max_int_32:
                 self._throw_value_error(proto_type, primitive)
-        # elif proto_type == proto.ENUM:
-        #     # This is not a primitive!
-        #     self._throw_type_error(primitive)
+        elif proto_type == proto.ENUM:
+            # Do nothing - this is not a primitive
+            pass
         elif proto_type == proto.SFIXED32:
             if _type != int:
                 self._throw_type_error(primitive)

--- a/tests/test_fields_composite.py
+++ b/tests/test_fields_composite.py
@@ -24,6 +24,7 @@ def test_composite_init():
         foo = proto.Field(proto.MESSAGE, number=1, message=Foo)
         eggs = proto.Field(proto.BOOL, number=2)
 
+
     spam = Spam(foo=Foo(bar="str", baz=42))
     assert spam.foo.bar == "str"
     assert spam.foo.baz == 42

--- a/tests/test_fields_map_composite.py
+++ b/tests/test_fields_map_composite.py
@@ -31,6 +31,23 @@ def test_composite_map():
     assert "k" not in baz.foos
 
 
+def test_composite_map_with_stale_fields():
+    class Foo(proto.Message):
+        bar = proto.Field(proto.INT32, number=1)
+
+    class Baz(proto.Message):
+        foos = proto.MapField(proto.STRING, proto.MESSAGE, number=1, message=Foo,)
+        name = proto.Field(proto.STRING, number=2)
+
+    baz = Baz(foos={"i": Foo(bar=42), "j": Foo(bar=24)})
+    baz.name = "New Value"
+    assert "name" in baz._stale_fields
+    foo = baz.foos["i"]
+    foo.bar = 100
+    assert Baz.to_dict(baz)["name"] == "New Value"
+    assert Baz.to_dict(baz)["foos"]["i"]["bar"] == 100
+
+
 def test_composite_map_dict():
     class Foo(proto.Message):
         bar = proto.Field(proto.INT32, number=1)

--- a/tests/test_fields_optional.py
+++ b/tests/test_fields_optional.py
@@ -59,6 +59,7 @@ def test_optional_and_oneof():
     assert s.mass_kg == 20
     assert not s.mass_lbs
     assert Squid.iridiphore_num in s
+    assert s.iridiphore_num == 600
 
     s = Squid(mass_lbs=40, iridiphore_num=600)
     assert not s.mass_kg

--- a/tests/test_marshal_types_wrappers_bool.py
+++ b/tests/test_marshal_types_wrappers_bool.py
@@ -66,8 +66,11 @@ def test_bool_value_write_bool_value():
         bar = proto.Field(proto.MESSAGE, message=wrappers_pb2.BoolValue, number=1,)
 
     foo = Foo(bar=True)
+    assert foo.bar is True
     foo.bar = wrappers_pb2.BoolValue()
     assert foo.bar is False
+    foo.bar = wrappers_pb2.BoolValue(value=True)
+    assert foo.bar is True
 
 
 def test_bool_value_del():


### PR DESCRIPTION
Aims to speed up naive usage on proto-plus-python as a wrapper around primitive protobuf objects.

This PR replaces attribute misses on proto-plus objects, which wound up in the `__getattr__` override to query the hidden protobuf object directly, with descriptors which do the same inside a caching layer to optimize repeated access. This descriptor/caching layer also aims to avoid unnecessary marshaling altogether when circumstances allow, further reducing the runtime of basic tasks.

---

The following is a performance chart of several simple tasks executed against the same proto definitions, first as raw protobuf objects and again as a proto-plus object. The two definitions are:

_Note: All tasks were run 10,000 times._

| Generate a(n)... | pb2 | proto-plus (before refactor) | proto-plus (with refactor) | refactor impact |
|---|---|---|---|---|
| empty instance | 3ms | 10ms | 7ms | ⬇️ 30% 🟢 |
| populated instance | 9ms | 168ms | 118ms | ⬇️ 30% 🟢 |
| populated nested objs | 38ms | 211ms | 163ms | ⬇️ 23% 🟢 |
| populated nested objs (1x attribute reads) | 39ms | 326ms | 419ms | ⬆️ 29% 🔴 |
| populated nested objs (10x attribute reads) | 101ms | 2009ms | 706ms | ⬇️ 65% 🟢 |
| populated w serialization | 20ms | 195ms | 280ms | ⬆️ 43% 🔴 |
| populated w lots of fields | 25ms | 624ms | 440ms | ⬇️ 30% 🟢 |
| MapFields populated during init | 124ms | 799ms | 626ms | ⬇️ 21% 🟢 |
| MapFields populated after init | -- | 1079ms | 369ms | ⬇️ 66% 🟢 |
| deserializing objects | 116ms | 204ms | 180ms | ⬇️ 12% 🟢 |

---

When used as a dependency in python-datastore, the following proto-plus versions have these performance hydrating loaded 500 entities (network I/O is excluded):

| datastore version | notes | before googleapis/proto-plus-python#230 | with googleapis/proto-plus-python#230 |
|--|--|--|--|
| 1.15.3 | before proto-plus | 360ms | _N/A_ |
| 2.0.0 | with proto-plus | 675ms | 800ms |
| 2.1.2 | proto-plus usage optimized <br> via googleapis/python-datastore#155) | 550ms | 750ms |

---

Resolves #222