### PR TITLE
chore: enable cpp tests for 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,10 +48,6 @@ jobs:
       matrix:
         python: [3.6, 3.7, 3.8, 3.9]
         variant: ['', cpp]
-        # Note: as of 2021-02-09, there are no 3.9 python wheels for protobuf/grpc
-        exclude:
-          - python: 3.9
-            variant: cpp
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -54,7 +54,7 @@ def unit(session, proto="python"):
 # Check if protobuf has released wheels for new python versions
 # https://pypi.org/project/protobuf/#files
 # This list will generally be shorter than 'unit'
-@nox.session(python=["3.6", "3.7", "3.8"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
 def unitcpp(session):
     return unit(session, proto="cpp")
 


### PR DESCRIPTION
Binary wheels for protoc for python 3.9 have been published, so the
corresponding unit tests should be enabled.