### PR TITLE
fix: add an option to define a "proto name" for a field

### DIFF
--- a/proto/fields.py
+++ b/proto/fields.py
@@ -36,7 +36,8 @@ class Field:
         enum=None,
         oneof: str = None,
         json_name: str = None,
-        optional: bool = False
+        optional: bool = False,
+        proto_name: str = None,
     ):
         # This class is not intended to stand entirely alone;
         # data is augmented by the metaclass for Message.
@@ -63,6 +64,7 @@ class Field:
         self.json_name = json_name
         self.optional = optional
         self.oneof = oneof
+        self.proto_name = proto_name
 
         # Once the descriptor is accessed the first time, cache it.
         # This is important because in rare cases the message or enum
@@ -117,7 +119,8 @@ class Field:
     @property
     def name(self) -> str:
         """Return the name of the field."""
-        return self.mcls_data["name"]
+        # If there is a proto name explicitly passed use that.
+        return self.proto_name or self.mcls_data["name"]
 
     @property
     def package(self) -> str:

--- a/tests/test_fields_composite.py
+++ b/tests/test_fields_composite.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import proto
+from google.api_core import protobuf_helpers
 
 
 def test_composite_init():
@@ -91,3 +92,19 @@ def test_composite_del():
     assert not spam.foo
     assert isinstance(spam.foo, Foo)
     assert spam.foo.bar == ""
+
+
+def test_composite_custom_name():
+    class Mollusc(proto.Message):
+        class_ = proto.Field(proto.STRING, number=1, proto_name="class")
+
+    m = Mollusc(class_="Cephalopoda")
+
+    # Note that in the vanilla proto, the field is named "class", not "class_".
+    # We can't touch the field directly because that's a syntax error.
+    assert getattr(Mollusc.pb(m), "class", None) == m.class_
+
+    m.class_ = "Gastropoda"
+
+    fm = protobuf_helpers.field_mask(None, Mollusc.pb(m))
+    assert fm.paths == ["class"]


### PR DESCRIPTION
This is used for defining useful field masks, among other things.