### PR TITLE
docs: clarify that proto plus messages are not pickleable

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -59,7 +59,7 @@ def unitcpp(session):
     return unit(session, proto="cpp")
 
 
-@nox.session(python="3.7")
+@nox.session(python="3.9")
 def docs(session):
     """Build the docs."""
 


### PR DESCRIPTION
Clarify that proto-plus messages are not pickleable, describe the
alternative, and give a multiprocessing example.

Note: in the future, we _may_ enable pickling proto-plus messages
through custom extensions as described in
https://docs.python.org/3/library/pickle.html#pickling-class-instances

This is _not_ guaranteed. For the foreseeable future, the preferred
method of serializing and deserializing proto-plus messages is
Message.serialize and Message.deserialize

Closes #162