### PR TITLE
fix: setting 64bit fields from strings supported

### DIFF
--- a/docs/marshal.rst
+++ b/docs/marshal.rst
@@ -72,7 +72,28 @@ Protocol buffer type                Python type             Nullable
 
   assert msg == msg_pb == msg_two
 
+.. warning::
 
+   Due to certain browser/javascript limitations, 64 bit sized fields, e.g. INT64, UINT64,
+   are converted to strings when marshalling messages to dictionaries or JSON.
+   Decoding JSON handles this correctly, but dicts must be unpacked when reconstructing messages. This is necessary to trigger a special case workaround.
+
+   .. code-block:: python
+
+      import proto
+
+      class MyMessage(proto.Message):
+          serial_id = proto.Field(proto.INT64, number=1)
+
+      msg = MyMessage(serial_id=12345)
+      msg_dict = MyMessage.to_dict(msg)
+
+      msg_2 = MyMessage(msg_dict)  # Raises an exception
+
+      msg_3 = MyMessage(**msg_dict) # Works without exception
+      assert msg == msg_3
+      
+  
 Wrapper types
 -------------
 

--- a/docs/marshal.rst
+++ b/docs/marshal.rst
@@ -71,27 +71,6 @@ Protocol buffer type                Python type             Nullable
   msg_two = MyMessage(msg_dict)
 
   assert msg == msg_pb == msg_two
-
-.. warning::
-
-   Due to certain browser/javascript limitations, 64 bit sized fields, e.g. INT64, UINT64,
-   are converted to strings when marshalling messages to dictionaries or JSON.
-   Decoding JSON handles this correctly, but dicts must be unpacked when reconstructing messages. This is necessary to trigger a special case workaround.
-
-   .. code-block:: python
-
-      import proto
-
-      class MyMessage(proto.Message):
-          serial_id = proto.Field(proto.INT64, number=1)
-
-      msg = MyMessage(serial_id=12345)
-      msg_dict = MyMessage.to_dict(msg)
-
-      msg_2 = MyMessage(msg_dict)  # Raises an exception
-
-      msg_3 = MyMessage(**msg_dict) # Works without exception
-      assert msg == msg_3
       
   
 Wrapper types

--- a/docs/marshal.rst
+++ b/docs/marshal.rst
@@ -76,7 +76,8 @@ Protocol buffer type                Python type             Nullable
 
    Due to certain browser/javascript limitations, 64 bit sized fields, e.g. INT64, UINT64,
    are converted to strings when marshalling messages to dictionaries or JSON.
-   Decoding JSON handles this correctly, but dicts must be unpacked when reconstructing messages. This is necessary to trigger a special case workaround.
+   Decoding JSON handles this correctly, but dicts must be unpacked when reconstructing messages.
+   This is necessary to trigger a special case workaround.
 
    .. code-block:: python
 

--- a/proto/marshal/marshal.py
+++ b/proto/marshal/marshal.py
@@ -26,6 +26,7 @@ from proto.marshal.collections import MapComposite
 from proto.marshal.collections import Repeated
 from proto.marshal.collections import RepeatedComposite
 from proto.marshal.rules import bytes as pb_bytes
+from proto.marshal.rules import stringy_numbers
 from proto.marshal.rules import dates
 from proto.marshal.rules import struct
 from proto.marshal.rules import wrappers
@@ -146,6 +147,11 @@ class BaseMarshal:
 
         # Special case for bytes to allow base64 encode/decode
         self.register(ProtoType.BYTES, pb_bytes.BytesRule())
+
+        # Special case for int64 from strings because of dict round trip.
+        # See https://github.com/protocolbuffers/protobuf/issues/2679
+        for rule_class in stringy_numbers.STRINGY_NUMBER_RULES:
+            self.register(rule_class._proto_type, rule_class())
 
     def to_python(self, proto_type, value, *, absent: bool = None):
         # Internal protobuf has its own special type for lists of values.

--- a/proto/marshal/rules/message.py
+++ b/proto/marshal/rules/message.py
@@ -29,7 +29,16 @@ class MessageRule:
         if isinstance(value, self._wrapper):
             return self._wrapper.pb(value)
         if isinstance(value, dict) and not self.is_map:
-            return self._descriptor(**value)
+            # We need to use the wrapper's marshaling to handle
+            # potentially problematic nested messages.
+            try:
+                # Try the fast path first.
+                return self._descriptor(**value)
+            except TypeError as ex:
+                # If we have a type error,
+                # try the slow path in case the error
+                # was an int64/string issue
+                return self._wrapper(value)._pb
         return value
 
     @property

--- a/proto/marshal/rules/stringy_numbers.py
+++ b/proto/marshal/rules/stringy_numbers.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2021  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from proto.primitives import ProtoType
+
+
+class StringyNumberRule:
+    """A marshal between certain numeric types and strings
+
+    This is a necessary hack to allow round trip conversion
+    from messages to dicts back to messages.
+
+    See https://github.com/protocolbuffers/protobuf/issues/2679
+    and
+    https://developers.google.com/protocol-buffers/docs/proto3#json
+    for more details.
+    """
+
+    def to_python(self, value, *, absent: bool = None):
+        return value
+
+    def to_proto(self, value):
+        return self._python_type(value)
+
+
+class Int64Rule(StringyNumberRule):
+    _python_type = int
+    _proto_type = ProtoType.INT64
+
+
+class UInt64Rule(StringyNumberRule):
+    _python_type = int
+    _proto_type = ProtoType.UINT64
+
+
+class SInt64Rule(StringyNumberRule):
+    _python_type = int
+    _proto_type = ProtoType.SINT64
+
+
+class Fixed64Rule(StringyNumberRule):
+    _python_type = int
+    _proto_type = ProtoType.FIXED64
+
+
+class SFixed64Rule(StringyNumberRule):
+    _python_type = int
+    _proto_type = ProtoType.SFIXED64
+
+
+STRINGY_NUMBER_RULES = [
+    Int64Rule,
+    UInt64Rule,
+    SInt64Rule,
+    Fixed64Rule,
+    SFixed64Rule,
+]

--- a/proto/message.py
+++ b/proto/message.py
@@ -67,7 +67,9 @@ class MessageMeta(type):
             # Determine the name of the entry message.
             msg_name = "{pascal_key}Entry".format(
                 pascal_key=re.sub(
-                    r"_\w", lambda m: m.group()[1:].upper(), key,
+                    r"_\w",
+                    lambda m: m.group()[1:].upper(),
+                    key,
                 ).replace(key[0], key[0].upper(), 1),
             )
 
@@ -83,20 +85,26 @@ class MessageMeta(type):
                 {
                     "__module__": attrs.get("__module__", None),
                     "__qualname__": "{prefix}.{name}".format(
-                        prefix=attrs.get("__qualname__", name), name=msg_name,
+                        prefix=attrs.get("__qualname__", name),
+                        name=msg_name,
                     ),
                     "_pb_options": {"map_entry": True},
                 }
             )
             entry_attrs["key"] = Field(field.map_key_type, number=1)
             entry_attrs["value"] = Field(
-                field.proto_type, number=2, enum=field.enum, message=field.message,
+                field.proto_type,
+                number=2,
+                enum=field.enum,
+                message=field.message,
             )
             map_fields[msg_name] = MessageMeta(msg_name, (Message,), entry_attrs)
 
             # Create the repeated field for the entry message.
             map_fields[key] = RepeatedField(
-                ProtoType.MESSAGE, number=field.number, message=map_fields[msg_name],
+                ProtoType.MESSAGE,
+                number=field.number,
+                message=map_fields[msg_name],
             )
 
         # Add the new entries to the attrs
@@ -288,7 +296,13 @@ class MessageMeta(type):
             if coerce:
                 obj = cls(obj)
             else:
-                raise TypeError("%r is not an instance of %s" % (obj, cls.__name__,))
+                raise TypeError(
+                    "%r is not an instance of %s"
+                    % (
+                        obj,
+                        cls.__name__,
+                    )
+                )
         return obj._pb
 
     def wrap(cls, pb):
@@ -394,7 +408,7 @@ class MessageMeta(type):
                 determines whether field name representations preserve
                 proto case (snake_case) or use lowerCamelCase. Default is True.
             including_default_value_fields (Optional(bool)): An option that
-                determines whether the default field values should be included in the results. 
+                determines whether the default field values should be included in the results.
                 Default is True.
 
         Returns:
@@ -453,7 +467,13 @@ class Message(metaclass=MessageMeta):
             message.
     """
 
-    def __init__(self, mapping=None, *, ignore_unknown_fields=False, **kwargs):
+    def __init__(
+        self,
+        mapping=None,
+        *,
+        ignore_unknown_fields=False,
+        **kwargs,
+    ):
         # We accept several things for `mapping`:
         #   * An instance of this class.
         #   * An instance of the underlying protobuf descriptor class.
@@ -493,7 +513,10 @@ class Message(metaclass=MessageMeta):
             # Sanity check: Did we get something not a map? Error if so.
             raise TypeError(
                 "Invalid constructor input for %s: %r"
-                % (self.__class__.__name__, mapping,)
+                % (
+                    self.__class__.__name__,
+                    mapping,
+                )
             )
 
         params = {}

--- a/proto/message.py
+++ b/proto/message.py
@@ -67,9 +67,7 @@ class MessageMeta(type):
             # Determine the name of the entry message.
             msg_name = "{pascal_key}Entry".format(
                 pascal_key=re.sub(
-                    r"_\w",
-                    lambda m: m.group()[1:].upper(),
-                    key,
+                    r"_\w", lambda m: m.group()[1:].upper(), key,
                 ).replace(key[0], key[0].upper(), 1),
             )
 
@@ -85,26 +83,20 @@ class MessageMeta(type):
                 {
                     "__module__": attrs.get("__module__", None),
                     "__qualname__": "{prefix}.{name}".format(
-                        prefix=attrs.get("__qualname__", name),
-                        name=msg_name,
+                        prefix=attrs.get("__qualname__", name), name=msg_name,
                     ),
                     "_pb_options": {"map_entry": True},
                 }
             )
             entry_attrs["key"] = Field(field.map_key_type, number=1)
             entry_attrs["value"] = Field(
-                field.proto_type,
-                number=2,
-                enum=field.enum,
-                message=field.message,
+                field.proto_type, number=2, enum=field.enum, message=field.message,
             )
             map_fields[msg_name] = MessageMeta(msg_name, (Message,), entry_attrs)
 
             # Create the repeated field for the entry message.
             map_fields[key] = RepeatedField(
-                ProtoType.MESSAGE,
-                number=field.number,
-                message=map_fields[msg_name],
+                ProtoType.MESSAGE, number=field.number, message=map_fields[msg_name],
             )
 
         # Add the new entries to the attrs
@@ -296,13 +288,7 @@ class MessageMeta(type):
             if coerce:
                 obj = cls(obj)
             else:
-                raise TypeError(
-                    "%r is not an instance of %s"
-                    % (
-                        obj,
-                        cls.__name__,
-                    )
-                )
+                raise TypeError("%r is not an instance of %s" % (obj, cls.__name__,))
         return obj._pb
 
     def wrap(cls, pb):
@@ -468,11 +454,7 @@ class Message(metaclass=MessageMeta):
     """
 
     def __init__(
-        self,
-        mapping=None,
-        *,
-        ignore_unknown_fields=False,
-        **kwargs,
+        self, mapping=None, *, ignore_unknown_fields=False, **kwargs,
     ):
         # We accept several things for `mapping`:
         #   * An instance of this class.
@@ -513,10 +495,7 @@ class Message(metaclass=MessageMeta):
             # Sanity check: Did we get something not a map? Error if so.
             raise TypeError(
                 "Invalid constructor input for %s: %r"
-                % (
-                    self.__class__.__name__,
-                    mapping,
-                )
+                % (self.__class__.__name__, mapping,)
             )
 
         params = {}

--- a/tests/test_fields_int.py
+++ b/tests/test_fields_int.py
@@ -115,6 +115,24 @@ def test_int64_dict_round_trip():
 
     s_dict = Squid.to_dict(s)
 
-    s2 = Squid(**s_dict)
+    s2 = Squid(s_dict)
 
     assert s == s2
+
+    # Double check that the conversion works with deeply nested messages.
+    class Clam(proto.Message):
+        class Shell(proto.Message):
+            class Pearl(proto.Message):
+                mass_kg = proto.Field(proto.INT64, number=1)
+
+            pearl = proto.Field(Pearl, number=1)
+
+        shell = proto.Field(Shell, number=1)
+
+    c = Clam(shell=Clam.Shell(pearl=Clam.Shell.Pearl(mass_kg=10)))
+
+    c_dict = Clam.to_dict(c)
+
+    c2 = Clam(c_dict)
+
+    assert c == c2


### PR DESCRIPTION
Due to limitations in certain browser/javascript combinations,
fields that are 64 bit integer types are converted to strings when
encoding a message to JSON or a dict.
Decoding from JSON handles this explicitly, but it makes converting
back from a dict an error.

This fix adds support for setting these 64 bit fields explicitly from
strings.

E.g.
```py
class Squid(proto.Message):
      mass_kg = proto.Field(proto.INT64, number=1)

s = Squid(mass_kg=10)
s_dict = Squid.to_dict(s)

assert s == Squid(s_dict)
s.mass_kg = "20"            # Supported
```