### PR TITLE
test: verify json_name is respected

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,16 @@ import nox
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
+PYTHON_VERSIONS = [
+    "3.6",
+    "3.7",
+    "3.8",
+    "3.9",
+    "3.10",
+]
+
+
+@nox.session(python=PYTHON_VERSIONS)
 def unit(session, proto="python"):
     """Run the unit test suite."""
 
@@ -54,12 +63,13 @@ def unit(session, proto="python"):
 # Check if protobuf has released wheels for new python versions
 # https://pypi.org/project/protobuf/#files
 # This list will generally be shorter than 'unit'
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=PYTHON_VERSIONS)
 def unitcpp(session):
     return unit(session, proto="cpp")
 
 
-@nox.session(python="3.9")
+# Just use the most recent version for docs
+@nox.session(python=PYTHON_VERSIONS[-1])
 def docs(session):
     """Build the docs."""
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     long_description=README,
     platforms="Posix; MacOS X",
     include_package_data=True,
-    install_requires=("protobuf >= 3.12.0",),
+    install_requires=("protobuf >= 3.19.0",),
     extras_require={"testing": ["google-api-core[grpc] >= 1.22.2",],},
     python_requires=">=3.6",
     classifiers=[

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -5,5 +5,4 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-protobuf==3.15.6
 google-api-core==1.22.2

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -148,3 +148,17 @@ def test_json_snake_case():
     assert s.mass_kg == 20
 
     assert Squid.to_json(s, preserving_proto_field_name=True) == json_str
+
+
+def test_json_name():
+    class Squid(proto.Message):
+        massKg = proto.Field(proto.INT32, number=1, json_name="mass_in_kilograms")
+
+    s = Squid(massKg=20)
+    j = Squid.to_json(s)
+
+    assert "mass_in_kilograms" in j
+
+    s_two = Squid.from_json(j)
+
+    assert s == s_two


### PR DESCRIPTION
Fields can customize their json name representation.
Add a test to verify that this customization is respected by both
Python and C++ runtimes.
Boost protobuf requirement to gain required upstream bugfix.