### PR TITLE
fix: add pickling support to proto messages

### DIFF
--- a/docs/messages.rst
+++ b/docs/messages.rst
@@ -246,8 +246,11 @@ already allows construction from mapping types.
 
 .. note::
 
-   Protobuf messages **CANNOT** be safely pickled or unpickled. This has serious consequences for programs that use multiprocessing or write messages to files.
-   The preferred mechanism for serializing proto messages is :meth:`~.Message.serialize`.
+   Although Python's pickling protocol has known issues when used with
+   untrusted collaborators, some frameworks do use it for communication
+   between trusted hosts.  To support such frameworks, protobuf messages
+   **can** be pickled and unpickled, although the preferred mechanism for
+   serializing proto messages is :meth:`~.Message.serialize`.
 
    Multiprocessing example:
 

--- a/proto/message.py
+++ b/proto/message.py
@@ -642,6 +642,16 @@ class Message(metaclass=MessageMeta):
         if pb_value is not None:
             self._pb.MergeFrom(self._meta.pb(**{key: pb_value}))
 
+    def __getstate__(self):
+        """Serialize for pickling."""
+        return self._pb.SerializeToString()
+
+    def __setstate__(self, value):
+        """Deserialization for pickling."""
+        new_pb = self._meta.pb().FromString(value)
+        super().__setattr__("_pb", new_pb)
+
+
 
 class _MessageInfo:
     """Metadata about a message.

--- a/proto/message.py
+++ b/proto/message.py
@@ -652,7 +652,6 @@ class Message(metaclass=MessageMeta):
         super().__setattr__("_pb", new_pb)
 
 
-
 class _MessageInfo:
     """Metadata about a message.
 

--- a/tests/test_message_pickling.py
+++ b/tests/test_message_pickling.py
@@ -1,0 +1,51 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+import pickle
+
+import pytest
+
+import proto
+
+
+class Squid(proto.Message):
+    # Test primitives, enums, and repeated fields.
+    class Chromatophore(proto.Message):
+        class Color(proto.Enum):
+            UNKNOWN = 0
+            RED = 1
+            BROWN = 2
+            WHITE = 3
+            BLUE = 4
+
+        color = proto.Field(Color, number=1)
+
+    mass_kg = proto.Field(proto.INT32, number=1)
+    chromatophores = proto.RepeatedField(Chromatophore, number=2)
+
+
+def test_pickling():
+
+    s = Squid(mass_kg=20)
+    colors = ["RED", "BROWN", "WHITE", "BLUE"]
+    s.chromatophores = [
+        {"color": c} for c in itertools.islice(itertools.cycle(colors), 10)
+    ]
+
+    pickled = pickle.dumps(s)
+
+    unpickled = pickle.loads(pickled)
+
+    assert unpickled == s


### PR DESCRIPTION
FBO of frameworks such as Apache Beam, which use them for sharing
state between trusted hosts.

Closes #260.