### PR TITLE
test: remove extraneous @staticmethod in test file

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -40,8 +40,7 @@ def unit(session, proto="python"):
     )
 
     session.env["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = proto
-    # Pytest 7.0.0 is buggy
-    session.install("coverage", "pytest<7.0.0", "pytest-cov", "pytz")
+    session.install("coverage", "pytest", "pytest-cov", "pytz")
     session.install("-e", ".[testing]", "-c", constraints_path)
 
     session.run(

--- a/tests/test_datetime_helpers.py
+++ b/tests/test_datetime_helpers.py
@@ -173,7 +173,6 @@ def test_from_rfc3339_w_full_precision():
     assert stamp == expected
 
 
-@staticmethod
 @pytest.mark.parametrize(
     "fractional, nanos",
     [


### PR DESCRIPTION
This is what was causing the Internal Error with pytest 7.0.0