### PR TITLE
fix: mitigate collisions in field names

### DIFF
--- a/proto/message.py
+++ b/proto/message.py
@@ -524,6 +524,16 @@ class Message(metaclass=MessageMeta):
         # coerced.
         marshal = self._meta.marshal
         for key, value in mapping.items():
+            # Underscores may be appended to field names
+            # that collide with python or proto-plus keywords.
+            # In case a key only exists with a `_` suffix, coerce the key
+            # to include the `_` suffix. Is not possible to
+            # natively define the same field with a trailing underscore in protobuf.
+            # See related issue
+            # https://github.com/googleapis/python-api-core/issues/227
+            if key not in self._meta.fields and f"{key}_" in self._meta.fields:
+                key = f"{key}_"
+
             try:
                 pb_type = self._meta.fields[key].pb_type
             except KeyError:

--- a/proto/message.py
+++ b/proto/message.py
@@ -524,25 +524,26 @@ class Message(metaclass=MessageMeta):
         # coerced.
         marshal = self._meta.marshal
         for key, value in mapping.items():
-            # Underscores may be appended to field names
-            # that collide with python or proto-plus keywords.
-            # In case a key only exists with a `_` suffix, coerce the key
-            # to include the `_` suffix. Is not possible to
-            # natively define the same field with a trailing underscore in protobuf.
-            # See related issue
-            # https://github.com/googleapis/python-api-core/issues/227
-            if key not in self._meta.fields and f"{key}_" in self._meta.fields:
-                key = f"{key}_"
-
             try:
                 pb_type = self._meta.fields[key].pb_type
             except KeyError:
-                if ignore_unknown_fields:
-                    continue
+                # Underscores may be appended to field names
+                # that collide with python or proto-plus keywords.
+                # In case a key only exists with a `_` suffix, coerce the key
+                # to include the `_` suffix. Is not possible to
+                # natively define the same field with a trailing underscore in protobuf.
+                # See related issue
+                # https://github.com/googleapis/python-api-core/issues/227
+                if f"{key}_" in self._meta.fields:
+                    key = f"{key}_"
+                    pb_type = self._meta.fields[key].pb_type
+                else:
+                    if ignore_unknown_fields:
+                        continue
 
-                raise ValueError(
-                    "Unknown field for {}: {}".format(self.__class__.__name__, key)
-                )
+                    raise ValueError(
+                        "Unknown field for {}: {}".format(self.__class__.__name__, key)
+                    )
 
             pb_value = marshal.to_proto(pb_type, value)
             if pb_value is not None:

--- a/tests/test_fields_mitigate_collision.py
+++ b/tests/test_fields_mitigate_collision.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_fields_mitigate_collision.py
+++ b/tests/test_fields_mitigate_collision.py
@@ -31,11 +31,5 @@ def test_fields_mitigate_collision():
     obj.eggs = "has_eggs"
     assert obj.spam_ == "has_spam"
 
-    modified_obj = TestMessage(
-        {
-           "spam": "has_spam",
-           "eggs": "has_eggs"
-        }
-    )
-
+    modified_obj = TestMessage({"spam": "has_spam", "eggs": "has_eggs"})
     assert modified_obj.spam_ == "has_spam"

--- a/tests/test_fields_mitigate_collision.py
+++ b/tests/test_fields_mitigate_collision.py
@@ -1,0 +1,41 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import proto
+
+
+# Underscores may be appended to field names
+# that collide with python or proto-plus keywords.
+# In case a key only exists with a `_` suffix, coerce the key
+# to include the `_` suffix. Is not possible to
+# natively define the same field with a trailing underscore in protobuf.
+# See related issue
+# https://github.com/googleapis/python-api-core/issues/227
+def test_fields_mitigate_collision():
+    class TestMessage(proto.Message):
+        spam_ = proto.Field(proto.STRING, number=1)
+        eggs = proto.Field(proto.STRING, number=2)
+
+    obj = TestMessage(spam_="has_spam")
+    obj.eggs = "has_eggs"
+    assert obj.spam_ == "has_spam"
+
+    modified_obj = TestMessage(
+        {
+           "spam": "has_spam",
+           "eggs": "has_eggs"
+        }
+    )
+
+    assert modified_obj.spam_ == "has_spam"

--- a/tests/test_fields_mitigate_collision.py
+++ b/tests/test_fields_mitigate_collision.py
@@ -31,5 +31,6 @@ def test_fields_mitigate_collision():
     obj.eggs = "has_eggs"
     assert obj.spam_ == "has_spam"
 
+    # Test that `spam` is coerced to `spam_`
     modified_obj = TestMessage({"spam": "has_spam", "eggs": "has_eggs"})
     assert modified_obj.spam_ == "has_spam"


### PR DESCRIPTION
Underscores may be appended to field names that collide with python or proto-plus keywords. In case a key only exists with a `_` suffix, coerce the key to include the `_` suffix. It's not possible to natively define the same field with a trailing underscore in protobuf. See related issue https://github.com/googleapis/python-api-core/issues/227