### PR TITLE
build: switch to release-please for tagging

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,1 +1,2 @@
 releaseType: python
+handleGHRelease: true

--- a/.github/release-trigger.yml
+++ b/.github/release-trigger.yml
@@ -1,0 +1,2 @@
+enabled: true
+


### PR DESCRIPTION
This will allow release please to create releases in Github instead of autorelease. 