### PR TITLE
fix: default proto package name is the module name, not ""

### DIFF
--- a/proto/_package_info.py
+++ b/proto/_package_info.py
@@ -33,7 +33,7 @@ def compile(name, attrs):
     # Pull a reference to the module where this class is being
     # declared.
     module = sys.modules.get(attrs.get("__module__"))
-    module_name = module.__name__ if hasattr(module, __name__) else ''
+    module_name = module.__name__ if hasattr(module, __name__) else ""
     proto_module = getattr(module, "__protobuf__", object())
 
     # A package should be present; get the marshal from there.

--- a/proto/_package_info.py
+++ b/proto/_package_info.py
@@ -36,7 +36,7 @@ def compile(name, attrs):
     proto_module = getattr(module, "__protobuf__", object())
 
     # A package should be present; get the marshal from there.
-    package = getattr(proto_module, "package", "")
+    package = getattr(proto_module, "package", module.__name__)
     marshal = Marshal(name=getattr(proto_module, "marshal", package))
 
     # Done; return the data.

--- a/proto/_package_info.py
+++ b/proto/_package_info.py
@@ -33,10 +33,11 @@ def compile(name, attrs):
     # Pull a reference to the module where this class is being
     # declared.
     module = sys.modules.get(attrs.get("__module__"))
+    module_name = module.__name__ if hasattr(module, __name__) else ''
     proto_module = getattr(module, "__protobuf__", object())
 
     # A package should be present; get the marshal from there.
-    package = getattr(proto_module, "package", module.__name__)
+    package = getattr(proto_module, "package", module_name)
     marshal = Marshal(name=getattr(proto_module, "marshal", package))
 
     # Done; return the data.


### PR DESCRIPTION
Fixes #175

This is similar to #176 but the PR is stale and the branch is no longer active