### PR TITLE
ci: refactor coverage check

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,6 @@
 branch = True
 
 [report]
-fail_under = 100
 show_missing = True
 omit =
     proto/marshal/compat.py

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -12,8 +12,12 @@ branchProtectionRules:
     - 'unit (3.7)'
     - 'unit (3.7, cpp)'
     - 'unit (3.8)'
-    # - 'unit (3.9, cpp)' # Don't have binary wheels for 3.9 cpp protobuf yet
+    - 'unit (3.9, cpp)'
     - 'unit (3.9)'
+    - 'unit (3.10, cpp)'
+    - 'unit (3.10)'
+    - cover
+    - OwlBot Post Processor
     - 'cla/google'
   requiredApprovingReviewCount: 1
   requiresCodeOwnerReviews: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,12 +58,40 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
-      - name: Install nox and codecov.
+      - name: Install nox
         run: |
           pip install nox
-          pip install codecov
-      - name: Run unit tests.
-        run: nox -s unit${{ matrix.variant }}-${{ matrix.python }}
-      - name: Submit coverage data to codecov.
-        run: codecov
-        if: always()
+      - name: Run unit tests
+        env:
+          COVERAGE_FILE: .coverage-${{ matrix.variant }}-${{ matrix.python }}
+        run: |
+          nox -s unit${{ matrix.variant }}-${{ matrix.python }}
+      - name: Upload coverage results
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-artifacts
+          path: .coverage-${{ matrix.variant }}-${{ matrix.python }}
+  cover:
+    runs-on: ubuntu-latest
+    needs:
+        - unit
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install coverage
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install coverage
+    - name: Download coverage results
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage-artifacts
+        path: .coverage-results/
+    - name: Report coverage results
+      run: |
+        coverage combine .coverage-results/.coverage*
+        coverage report --show-missing --fail-under=100

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Proto Plus for Python
 =====================
 
-|pypi| |release level| |docs| |codecov|
+|pypi| |release level| |docs|
 
     Beautiful, Pythonic protocol buffers.
 
@@ -26,5 +26,3 @@ Documentation
   :target: https://cloud.google.com/terms/launch-stages
 .. |docs| image:: https://readthedocs.org/projects/proto-plus-python/badge/?version=latest
   :target: https://proto-plus-python.readthedocs.io/en/latest/
-.. |codecov| image:: https://codecov.io/gh/googleapis/proto-plus-python/graph/badge.svg
-  :target: https://codecov.io/gh/googleapis/proto-plus-python


### PR DESCRIPTION
This PR refactors the github action coverage check to test combined coverage across all checks. This is needed for https://github.com/googleapis/proto-plus-python/pull/226 as there is a coverage gap when checks are evaluated individually rather than combined.

We use a similar check in googleapis python-* repos. See the templated file [here](https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/python_library/.github/workflows/unittest.yml#L45).