### PR TITLE
fix(deps): require protobuf>= 3.15.0, <4.0.0dev

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,10 +36,10 @@ setup(
     long_description=README,
     platforms="Posix; MacOS X",
     include_package_data=True,
-    install_requires=("protobuf >= 3.19.0",),
+    install_requires=("protobuf >= 3.19.0, <4.0.0dev",),
     extras_require={
         "testing": [
-            "google-api-core[grpc] >= 1.22.2",
+            "google-api-core[grpc] >= 1.31.5",
         ],
     },
     python_requires=">=3.6",

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -5,5 +5,5 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-google-api-core==1.22.2
+google-api-core==1.31.5
 protobuf==3.19.0


### PR DESCRIPTION
fix(deps): require google-api-core[grpc] >= 1.31.5