### PR TITLE
fix: Add support for Python 3.11

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -16,6 +16,8 @@ branchProtectionRules:
     - 'unit (3.9)'
     - 'unit (3.10, cpp)'
     - 'unit (3.10)'
+    - 'unit (3.11, cpp)'
+    - 'unit (3.11)'
     - cover
     - OwlBot Post Processor
     - 'cla/google'

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -16,7 +16,6 @@ branchProtectionRules:
     - 'unit (3.9)'
     - 'unit (3.10, cpp)'
     - 'unit (3.10)'
-    - 'unit (3.11, cpp)'
     - 'unit (3.11)'
     - cover
     - OwlBot Post Processor

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,9 @@ jobs:
       matrix:
         python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
         variant: ['', 'cpp', 'upb']
+        exclude:
+          - option: "cpp"
+            python: 3.11
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Build the documentation.
         run: nox -s docs
   unit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11.0-beta.3']
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
         variant: ['', 'cpp', 'upb']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11.0-beta.3']
         variant: ['', 'cpp', 'upb']
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,16 +61,22 @@ jobs:
       - name: Install nox
         run: |
           pip install nox
+        # Trim the Python version string
+      - name: Trim python version
+        run: |
+          PYTHON_VERSION_TRIMMED=${{ matrix.python }}
+          PYTHON_VERSION_TRIMMED=$(echo $PYTHON_VERSION_TRIMMED | cut -c1-4)
+          echo "PYTHON_VERSION_TRIMMED=$PYTHON_VERSION_TRIMMED" >> $GITHUB_ENV
       - name: Run unit tests
         env:
-          COVERAGE_FILE: .coverage-${{ matrix.variant }}-${{ matrix.python }}
+          COVERAGE_FILE: .coverage-${{ matrix.variant }}-${{ env.PYTHON_VERSION_TRIMMED }}
         run: |
-          nox -s unit${{ matrix.variant }}-${{ matrix.python }}
+          nox -s unit${{ matrix.variant }}-${{ env.PYTHON_VERSION_TRIMMED }}
       - name: Upload coverage results
         uses: actions/upload-artifact@v3
         with:
           name: coverage-artifacts
-          path: .coverage-${{ matrix.variant }}-${{ matrix.python }}
+          path: .coverage-${{ matrix.variant }}-${{ env.PYTHON_VERSION_TRIMMED }}
   cover:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.9"
       - name: Install nox.
         run: python -m pip install nox
       - name: Build the documentation.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
         variant: ['', 'cpp', 'upb']
         exclude:
-          - option: "cpp"
+          - variant: "cpp"
             python: 3.11
     steps:
       - uses: actions/checkout@v2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,6 +23,7 @@ CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 
 PYTHON_VERSIONS = [
+    "3.11.0-beta.3",
     "3.6",
     "3.7",
     "3.8",

--- a/noxfile.py
+++ b/noxfile.py
@@ -68,7 +68,7 @@ def unit(session, proto="python"):
 # Check if protobuf has released wheels for new python versions
 # https://pypi.org/project/protobuf/#files
 # This list will generally be shorter than 'unit'
-@nox.session(python=PYTHON_VERSIONS)
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
 def unitcpp(session):
     return unit(session, proto="cpp")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,13 +23,16 @@ CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 
 PYTHON_VERSIONS = [
-    "3.11.0-beta.3",
     "3.6",
     "3.7",
     "3.8",
     "3.9",
     "3.10",
+    "3.11",
 ]
+
+# Error if a python version is missing
+nox.options.error_on_missing_interpreters = True
 
 
 @nox.session(python=PYTHON_VERSIONS)
@@ -76,7 +79,7 @@ def unitupb(session):
 
 
 # Just use the most recent version for docs
-@nox.session(python=PYTHON_VERSIONS[-1])
+@nox.session(python=PYTHON_VERSIONS[-2])
 def docs(session):
     """Build the docs."""
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -78,7 +78,7 @@ def unitupb(session):
     return unit(session, proto="upb")
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def docs(session):
     """Build the docs."""
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -78,8 +78,7 @@ def unitupb(session):
     return unit(session, proto="upb")
 
 
-# Just use the most recent version for docs
-@nox.session(python=PYTHON_VERSIONS[-2])
+@nox.session(python="3.8")
 def docs(session):
     """Build the docs."""
 

--- a/proto/enums.py
+++ b/proto/enums.py
@@ -58,8 +58,11 @@ class ProtoEnumMeta(enum.EnumMeta):
         # In 3.7 onwards, we can define an _ignore_ attribute and do some
         # mucking around with that.
         if pb_options in attrs._member_names:
-            idx = attrs._member_names.index(pb_options)
-            attrs._member_names.pop(idx)
+            if isinstance(attrs._member_names, list):
+                idx = attrs._member_names.index(pb_options)
+                attrs._member_names.pop(idx)
+            else:  # Python 3.11.0b3
+                del attrs._member_names[pb_options]
 
         # Make the descriptor.
         enum_desc = descriptor_pb2.EnumDescriptorProto(

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Code Generators",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/tests/test_enum_total_ordering.py
+++ b/tests/test_enum_total_ordering.py
@@ -49,7 +49,11 @@ def test_total_ordering_w_other_enum_type():
 
     for item in enums_test.OtherEnum:
         assert not to_compare == item
-        assert to_compare.SOME_VALUE != item
+        assert type(to_compare).SOME_VALUE != item
+        try:
+            assert to_compare.SOME_VALUE != item
+        except AttributeError:  # Python 3.11.0b3
+            pass
         with pytest.raises(TypeError):
             assert not to_compare < item
         with pytest.raises(TypeError):


### PR DESCRIPTION
There are two changes:

Changes in the actual code:

 - _member_names changed from a list to a dict in https://github.com/python/cpython/pull/28907
    - we instance-check and remove by list-specific or dict-specific way

Change in the tests only:

 - accessing other enum members via instance attributes is no longer possible
    - we access them via the class instead
    - we leave the original test in a try-except block

Some of the Python enum changes might get reverted,
see https://github.com/python/cpython/issues/93910
But the fix is backwards compatible.

Fixes https://github.com/googleapis/proto-plus-python/issues/326