### PR TITLE
chore: update renovate bot configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
   "extends": [
-    "config:base"
+      "config:base",
+      "group:all",
+      ":disableDependencyDashboard",
+      "schedule:weekly"
+  ],
+  "ignorePaths": [
+    ".kokoro/requirements.txt"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,9 @@
 {
   "extends": [
-      "config:base",
-      "group:all",
-      ":disableDependencyDashboard",
-      "schedule:weekly"
+    "config:base",
+    "group:all",
+    ":disableDependencyDashboard",
+    "schedule:weekly"
   ],
   "ignorePaths": [
     ".kokoro/requirements.txt"


### PR DESCRIPTION
- exclude `.kokoro/requirements.txt` which is part of synthtool templates
- run weekly
- group PRs