### PR TITLE
feat: Add additional parameters to `to_json()` and `to_dict()` methods

### DIFF
--- a/proto/message.py
+++ b/proto/message.py
@@ -393,7 +393,7 @@ class MessageMeta(type):
                 proto case (snake_case) or use lowerCamelCase. Default is False.
             sort_keys (Optional(bool)): If True, then the output will be sorted by field names.
                 Default is False.
-            indent (int): The JSON object will be pretty-printed with this indent level.
+            indent (Optional(int)): The JSON object will be pretty-printed with this indent level.
                 An indent level of 0 or negative will only insert newlines.
                 Pass None for the most compact representation without newlines.
             float_precision (Optional(int)): If set, use this to specify float field valid digits.

--- a/proto/message.py
+++ b/proto/message.py
@@ -376,7 +376,10 @@ class MessageMeta(type):
         use_integers_for_enums=True,
         including_default_value_fields=True,
         preserving_proto_field_name=False,
+        sort_keys=False,
         indent=2,
+        float_precision=None,
+        ensure_ascii=False,
     ) -> str:
         """Given a message instance, serialize it to json
 
@@ -389,10 +392,16 @@ class MessageMeta(type):
             preserving_proto_field_name (Optional(bool)): An option that
                 determines whether field name representations preserve
                 proto case (snake_case) or use lowerCamelCase. Default is False.
-            indent: The JSON object will be pretty-printed with this indent level.
+            sort_keys (Optional(bool)): If True, then the output will be sorted by field names.
+                Default is False.
+            indent (int): The JSON object will be pretty-printed with this indent level.
                 An indent level of 0 or negative will only insert newlines.
                 Pass None for the most compact representation without newlines.
-
+            float_precision (Optional(int)): If set, use this to specify float field valid digits.
+                Default is None.
+            ensure_ascii (Optional(bool)): If True, strings with non-ASCII characters are escaped.
+                If False, Unicode strings are returned unchanged.
+                Default is False.
         Returns:
             str: The json string representation of the protocol buffer.
         """
@@ -401,7 +410,10 @@ class MessageMeta(type):
             use_integers_for_enums=use_integers_for_enums,
             including_default_value_fields=including_default_value_fields,
             preserving_proto_field_name=preserving_proto_field_name,
+            sort_keys=sort_keys,
             indent=indent,
+            float_precision=float_precision,
+            ensure_ascii=ensure_ascii,
         )
 
     def from_json(cls, payload, *, ignore_unknown_fields=False) -> "Message":
@@ -428,6 +440,7 @@ class MessageMeta(type):
         use_integers_for_enums=True,
         preserving_proto_field_name=True,
         including_default_value_fields=True,
+        float_precision=None,
     ) -> "Message":
         """Given a message instance, return its representation as a python dict.
 
@@ -443,6 +456,8 @@ class MessageMeta(type):
             including_default_value_fields (Optional(bool)): An option that
                 determines whether the default field values should be included in the results.
                 Default is True.
+            float_precision (Optional(int)): If set, use this to specify float field valid digits.
+                Default is None.
 
         Returns:
             dict: A representation of the protocol buffer using pythonic data structures.
@@ -454,6 +469,7 @@ class MessageMeta(type):
             including_default_value_fields=including_default_value_fields,
             preserving_proto_field_name=preserving_proto_field_name,
             use_integers_for_enums=use_integers_for_enums,
+            float_precision=float_precision,
         )
 
     def copy_from(cls, instance, other):

--- a/proto/message.py
+++ b/proto/message.py
@@ -379,7 +379,6 @@ class MessageMeta(type):
         sort_keys=False,
         indent=2,
         float_precision=None,
-        ensure_ascii=False,
     ) -> str:
         """Given a message instance, serialize it to json
 
@@ -399,9 +398,6 @@ class MessageMeta(type):
                 Pass None for the most compact representation without newlines.
             float_precision (Optional(int)): If set, use this to specify float field valid digits.
                 Default is None.
-            ensure_ascii (Optional(bool)): If True, strings with non-ASCII characters are escaped.
-                If False, Unicode strings are returned unchanged.
-                Default is False.
         Returns:
             str: The json string representation of the protocol buffer.
         """
@@ -413,7 +409,6 @@ class MessageMeta(type):
             sort_keys=sort_keys,
             indent=indent,
             float_precision=float_precision,
-            ensure_ascii=ensure_ascii,
         )
 
     def from_json(cls, payload, *, ignore_unknown_fields=False) -> "Message":

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     long_description=README,
     platforms="Posix; MacOS X",
     include_package_data=True,
-    install_requires=("protobuf >= 3.19.0, <5.0.0dev",),
+    install_requires=("protobuf >= 3.20.0, <5.0.0dev",),
     extras_require={
         "testing": [
             "google-api-core[grpc] >= 1.31.5",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     long_description=README,
     platforms="Posix; MacOS X",
     include_package_data=True,
-    install_requires=("protobuf >= 3.20.0, <5.0.0dev",),
+    install_requires=("protobuf >= 3.19.0, <5.0.0dev",),
     extras_require={
         "testing": [
             "google-api-core[grpc] >= 1.31.5",

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -183,7 +183,7 @@ def test_json_sort_keys():
     s = Squid(name="Steve", mass_kg=20)
     j = Squid.to_json(s, sort_keys=True)
 
-    assert re.match(re.compile(r"massKg.|\s*name"), j)
+    assert re.match(r"massKg.*name", j, re.DOTALL)
 
 
 def test_json_float_precision():
@@ -194,4 +194,4 @@ def test_json_float_precision():
     s = Squid(name="Steve", mass_kg=3.14159265)
     j = Squid.to_json(s, float_precision=3, indent=None)
 
-    assert j == '{"name":"Steve","massKg":3.14}'
+    assert j == '{"name": "Steve","massKg": 3.14}'

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -181,9 +181,9 @@ def test_json_sort_keys():
         mass_kg = proto.Field(proto.INT32, number=2)
 
     s = Squid(name="Steve", mass_kg=20)
-    j = Squid.to_json(s, sort_keys=True)
+    j = Squid.to_json(s, sort_keys=True, indent=None)
 
-    assert re.match(r"massKg.*name", j, re.DOTALL)
+    assert re.match(r"massKg.*name", j)
 
 
 def test_json_float_precision():
@@ -194,4 +194,4 @@ def test_json_float_precision():
     s = Squid(name="Steve", mass_kg=3.14159265)
     j = Squid.to_json(s, float_precision=3, indent=None)
 
-    assert j == '{"name": "Steve","massKg": 3.14}'
+    assert j == '{"name": "Steve", "massKg": 3.14}'

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -183,7 +183,7 @@ def test_json_sort_keys():
     s = Squid(name="Steve", mass_kg=20)
     j = Squid.to_json(s, sort_keys=True)
 
-    assert re.match(r"massKg.|\s*name", j)
+    assert re.match(r"massKg.|\n*name", j)
 
 
 def test_json_float_precision():
@@ -192,6 +192,14 @@ def test_json_float_precision():
         mass_kg = proto.Field(proto.FLOAT, number=2)
 
     s = Squid(name="Steve", mass_kg=3.14159265)
-    j = Squid.to_json(s, float_precision=2)
+    j = Squid.to_json(s, float_precision=3)
 
-    assert j == '{"name":"Steve","massKg":3.14}'
+    assert (
+        j
+        == """
+    {
+      "name": "Steve",
+      "massKg": 3.14
+    }
+    """
+    )

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -186,6 +186,7 @@ def test_json_sort_keys():
     assert re.search(r"massKg.*name", j)
 
 
+# TODO: https://github.com/googleapis/proto-plus-python/issues/390
 def test_json_float_precision():
     class Squid(proto.Message):
         name = proto.Field(proto.STRING, number=1)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+import re
 
 import proto
 from google.protobuf.json_format import MessageToJson, Parse, ParseError
@@ -172,3 +173,25 @@ def test_json_name():
     s_two = Squid.from_json(j)
 
     assert s == s_two
+
+
+def test_json_sort_keys():
+    class Squid(proto.Message):
+        name = proto.Field(proto.STRING, number=1)
+        mass_kg = proto.Field(proto.INT32, number=2)
+
+    s = Squid(name="Steve", mass_kg=20)
+    j = Squid.to_json(s, sort_keys=True)
+
+    assert re.match(r"massKg.|\s*name", j)
+
+
+def test_json_float_precision():
+    class Squid(proto.Message):
+        name = proto.Field(proto.STRING, number=1)
+        mass_kg = proto.Field(proto.FLOAT, number=2)
+
+    s = Squid(name="Steve", mass_kg=3.14159265)
+    j = Squid.to_json(s, float_precision=2)
+
+    assert j == '{"name":"Steve","massKg":3.14}'

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -183,7 +183,7 @@ def test_json_sort_keys():
     s = Squid(name="Steve", mass_kg=20)
     j = Squid.to_json(s, sort_keys=True)
 
-    assert re.match(r"massKg.|\n*name", j)
+    assert re.match(re.compile(r"massKg.|\s*name"), j)
 
 
 def test_json_float_precision():
@@ -192,14 +192,6 @@ def test_json_float_precision():
         mass_kg = proto.Field(proto.FLOAT, number=2)
 
     s = Squid(name="Steve", mass_kg=3.14159265)
-    j = Squid.to_json(s, float_precision=3)
+    j = Squid.to_json(s, float_precision=3, indent=None)
 
-    assert (
-        j
-        == """
-    {
-      "name": "Steve",
-      "massKg": 3.14
-    }
-    """
-    )
+    assert j == '{"name":"Steve","massKg":3.14}'

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -183,7 +183,7 @@ def test_json_sort_keys():
     s = Squid(name="Steve", mass_kg=20)
     j = Squid.to_json(s, sort_keys=True, indent=None)
 
-    assert re.match(r"massKg.*name", j)
+    assert re.search(r"massKg.*name", j)
 
 
 def test_json_float_precision():

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -271,6 +271,16 @@ def test_serialize_to_dict():
     assert new_s == s
 
 
+def test_serialize_to_dict_float_precision():
+    class Squid(proto.Message):
+        mass_kg = proto.Field(proto.FLOAT, number=1)
+
+    s = Squid(mass_kg=3.14159265)
+
+    s_dict = Squid.to_dict(s, float_precision=3)
+    assert s_dict["mass_kg"] == 3.14
+
+
 def test_unknown_field_deserialize():
     # This is a somewhat common setup: a client uses an older proto definition,
     # while the server sends the newer definition. The client still needs to be

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -271,6 +271,7 @@ def test_serialize_to_dict():
     assert new_s == s
 
 
+# TODO: https://github.com/googleapis/proto-plus-python/issues/390
 def test_serialize_to_dict_float_precision():
     class Squid(proto.Message):
         mass_kg = proto.Field(proto.FLOAT, number=1)


### PR DESCRIPTION
- These parameters are just passthroughs to [`MessageToJson`][1] and [`MessageToDict`][2]

[1]: https://googleapis.dev/python/protobuf/latest/google/protobuf/json_format.html#google.protobuf.json_format.MessageToJson

[2]: https://googleapis.dev/python/protobuf/latest/google/protobuf/json_format.html#google.protobuf.json_format.MessageToDict