### PR TITLE
feat: add support for proto.__version__

### DIFF
--- a/proto/__init__.py
+++ b/proto/__init__.py
@@ -20,6 +20,7 @@ from .marshal import Marshal
 from .message import Message
 from .modules import define_module as module
 from .primitives import ProtoType
+from .version import __version__
 
 
 DOUBLE = ProtoType.DOUBLE
@@ -42,6 +43,7 @@ SINT64 = ProtoType.SINT64
 
 
 __all__ = (
+    "__version__",
     "Enum",
     "Field",
     "MapField",

--- a/proto/version.py
+++ b/proto/version.py
@@ -1,0 +1,15 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+__version__ = "1.22.3"

--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,19 @@
 # limitations under the License.
 
 import io
+import re
 import os
 
 from setuptools import find_packages, setup
 
-version = "1.22.3"
-
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
+
+version = None
+
+with open(os.path.join(PACKAGE_ROOT, "proto/version.py")) as fp:
+    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    assert len(version_candidates) == 1
+    version = version_candidates[0]
 
 with io.open(os.path.join(PACKAGE_ROOT, "README.rst")) as file_obj:
     README = file_obj.read()


### PR DESCRIPTION
This PR migrates from using a hardcoded version in `setup.py` to a version module to make it easy to query the current version of proto-plus

```
(py39) partheniou@partheniou-vm-3:~/git/proto-plus-python$ python3
Python 3.9.16 (main, Mar  2 2023, 17:52:22) 
[GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import proto
>>> proto.__version__
'1.22.3'
```