### PR TITLE
chore: fix distribution name in .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -6,7 +6,7 @@
     "language": "python",
     "library_type": "CORE",
     "repo": "googleapis/proto-plus-python",
-    "distribution_name": "proto-plus-python",
+    "distribution_name": "proto-plus",
     "default_version": "",
     "codeowner_team": ""
 }


### PR DESCRIPTION
https://pypi.org/project/proto-plus/