### PR TITLE
fix: drop python 3.6

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -7,9 +7,6 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - 'style-check'
     - 'docs'
-    - 'unit (3.6, cpp)'
-    - 'unit (3.6, python)'
-    - 'unit (3.6, upb)'
     - 'unit (3.7, cpp)'
     - 'unit (3.7, python)'
     - 'unit (3.7, upb)'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         variant: ['cpp', 'python', 'upb']
         # TODO(https://github.com/googleapis/proto-plus-python/issues/389):
         # Remove the 'cpp' implementation once support for Protobuf 3.x is dropped.

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,4 +3,4 @@ build:
   image: latest
 python:
   pip_install: true
-  version: 3.6
+  version: 3.9

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,6 @@ CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 
 PYTHON_VERSIONS = [
-    "3.6",
     "3.7",
     "3.8",
     "3.9",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
             "google-api-core >= 1.31.5",
         ],
     },
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
@@ -56,7 +56,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -1,9 +1,0 @@
-# This constraints file is used to check that lower bounds
-# are correct in setup.py
-# List *all* library dependencies and extras in this file.
-# Pin the version to the lower bound.
-#
-# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
-# Then this file should have foo==1.14.0
-google-api-core==1.31.5
-protobuf==3.19.0


### PR DESCRIPTION
Remove python 3.6 which has already been dropped throughout the `googleapis` organization.