### PR TITLE
fix: Remove check for Protobuf version

### DIFF
--- a/proto/marshal/compat.py
+++ b/proto/marshal/compat.py
@@ -21,8 +21,6 @@
 from google.protobuf.internal import containers
 import google.protobuf
 
-PROTOBUF_VERSION = google.protobuf.__version__
-
 # Import protobuf 4.xx first and fallback to earlier version
 # if not present.
 try:
@@ -40,13 +38,6 @@ repeated_composite_types = (containers.RepeatedCompositeFieldContainer,)
 repeated_scalar_types = (containers.RepeatedScalarFieldContainer,)
 map_composite_types = (containers.MessageMap,)
 
-# In `proto/marshal.py`, for compatibility with protobuf 5.x,
-# we'll use `map_composite_type_names` to check whether
-# the name of the class of a protobuf type is
-# `MessageMapContainer`, and, if `True`, return a MapComposite.
-# See https://github.com/protocolbuffers/protobuf/issues/16596
-map_composite_type_names = ("MessageMapContainer",)
-
 if _message:
     repeated_composite_types += (_message.RepeatedCompositeContainer,)
     repeated_scalar_types += (_message.RepeatedScalarContainer,)
@@ -56,8 +47,15 @@ if _message:
     # the name of the class of a protobuf type is
     # `MessageMapContainer`, and, if `True`, return a MapComposite.
     # See https://github.com/protocolbuffers/protobuf/issues/16596
-    if PROTOBUF_VERSION[0:2] in ["3.", "4."]:
+    try:
         map_composite_types += (_message.MessageMapContainer,)
+    except:
+        # In `proto/marshal.py`, for compatibility with protobuf 5.x,
+        # we'll use `map_composite_type_names` to check whether
+        # the name of the class of a protobuf type is
+        # `MessageMapContainer`, and, if `True`, return a MapComposite.
+        # See https://github.com/protocolbuffers/protobuf/issues/16596
+        map_composite_type_names = ("MessageMapContainer",)
 
 __all__ = (
     "repeated_composite_types",

--- a/proto/marshal/compat.py
+++ b/proto/marshal/compat.py
@@ -37,16 +37,16 @@ repeated_composite_types = (containers.RepeatedCompositeFieldContainer,)
 repeated_scalar_types = (containers.RepeatedScalarFieldContainer,)
 map_composite_types = (containers.MessageMap,)
 
+# For compatibility with protobuf 5.x,
+# we'll fall back to `map_composite_type_names` to check whether
+# the name of the class of a protobuf type is
+# `MessageMapContainer`, and, if `True`, return a MapComposite.
+# See https://github.com/protocolbuffers/protobuf/issues/16596
+map_composite_type_names = ("MessageMapContainer",)
+
 if _message:
     repeated_composite_types += (_message.RepeatedCompositeContainer,)
     repeated_scalar_types += (_message.RepeatedScalarContainer,)
-
-    # For compatibility with protobuf 5.x,
-    # we'll fall back to `map_composite_type_names` to check whether
-    # the name of the class of a protobuf type is
-    # `MessageMapContainer`, and, if `True`, return a MapComposite.
-    # See https://github.com/protocolbuffers/protobuf/issues/16596
-    map_composite_type_names = ("MessageMapContainer",)
 
     try:
         map_composite_types += (_message.MessageMapContainer,)

--- a/proto/marshal/compat.py
+++ b/proto/marshal/compat.py
@@ -50,7 +50,7 @@ if _message:
 
     try:
         map_composite_types += (_message.MessageMapContainer,)
-    except:
+    except AttributeError:
         # The `MessageMapContainer` attribute is not available in Protobuf 5.x+
         pass
 

--- a/proto/marshal/compat.py
+++ b/proto/marshal/compat.py
@@ -37,8 +37,8 @@ repeated_composite_types = (containers.RepeatedCompositeFieldContainer,)
 repeated_scalar_types = (containers.RepeatedScalarFieldContainer,)
 map_composite_types = (containers.MessageMap,)
 
-# For compatibility with protobuf 5.x,
-# we'll fall back to `map_composite_type_names` to check whether
+# In `proto/marshal.py`, for compatibility with protobuf 5.x,
+# we'll use `map_composite_type_names` to check whether
 # the name of the class of a protobuf type is
 # `MessageMapContainer`, and, if `True`, return a MapComposite.
 # See https://github.com/protocolbuffers/protobuf/issues/16596

--- a/proto/marshal/compat.py
+++ b/proto/marshal/compat.py
@@ -19,7 +19,6 @@
 # not be included.
 
 from google.protobuf.internal import containers
-import google.protobuf
 
 # Import protobuf 4.xx first and fallback to earlier version
 # if not present.
@@ -42,20 +41,19 @@ if _message:
     repeated_composite_types += (_message.RepeatedCompositeContainer,)
     repeated_scalar_types += (_message.RepeatedScalarContainer,)
 
-    # In `proto/marshal.py`, for compatibility with protobuf 5.x,
-    # we'll use `map_composite_type_names` to check whether
+    # For compatibility with protobuf 5.x,
+    # we'll fall back to `map_composite_type_names` to check whether
     # the name of the class of a protobuf type is
     # `MessageMapContainer`, and, if `True`, return a MapComposite.
     # See https://github.com/protocolbuffers/protobuf/issues/16596
+    map_composite_type_names = ("MessageMapContainer",)
+
     try:
         map_composite_types += (_message.MessageMapContainer,)
     except:
-        # In `proto/marshal.py`, for compatibility with protobuf 5.x,
-        # we'll use `map_composite_type_names` to check whether
-        # the name of the class of a protobuf type is
-        # `MessageMapContainer`, and, if `True`, return a MapComposite.
-        # See https://github.com/protocolbuffers/protobuf/issues/16596
-        map_composite_type_names = ("MessageMapContainer",)
+        # The `MessageMapContainer` attribute is not available in Protobuf 5.x+
+        pass
+
 
 __all__ = (
     "repeated_composite_types",


### PR DESCRIPTION
This PR removes the check for `google.protobuf.__version__` and simply uses `try`, `catch` instead. If there is no attribute `MessageMapContainer` on `_message` , then the compatibility code introduced in https://github.com/googleapis/proto-plus-python/pull/433 is used.