### PR TITLE
fix: fix 'Couldn't build proto file' when using Python 3.13

### DIFF
--- a/proto/enums.py
+++ b/proto/enums.py
@@ -74,7 +74,7 @@ class ProtoEnumMeta(enum.EnumMeta):
                     descriptor_pb2.EnumValueDescriptorProto(name=name, number=number)
                     # Minor hack to get all the enum variants out.
                     for name, number in attrs.items()
-                    if isinstance(number, int)
+                    if name in attrs._member_names and isinstance(number, int)
                 ),
                 key=lambda v: v.number,
             ),

--- a/proto/enums.py
+++ b/proto/enums.py
@@ -73,6 +73,8 @@ class ProtoEnumMeta(enum.EnumMeta):
                 (
                     descriptor_pb2.EnumValueDescriptorProto(name=name, number=number)
                     # Minor hack to get all the enum variants out.
+                    # Use the `_member_names` property to get only the enum members
+                    # See https://github.com/googleapis/proto-plus-python/issues/490
                     for name, number in attrs.items()
                     if name in attrs._member_names and isinstance(number, int)
                 ),

--- a/tests/clam.py
+++ b/tests/clam.py
@@ -19,6 +19,7 @@ __protobuf__ = proto.module(
     manifest={
         "Clam",
         "Species",
+        "Color",
     },
 )
 
@@ -30,6 +31,14 @@ class Species(proto.Enum):
     GIGAS = 3
 
 
+class Color(proto.Enum):
+    COLOR_UNKNOWN = 0
+    BLUE = 1
+    ORANGE = 2
+    GREEN = 3
+
+
 class Clam(proto.Message):
     species = proto.Field(proto.ENUM, number=1, enum="Species")
     mass_kg = proto.Field(proto.DOUBLE, number=2)
+    color = proto.Field(proto.ENUM, number=3, enum="Color")


### PR DESCRIPTION
Fixes https://github.com/googleapis/proto-plus-python/issues/490