### PR TITLE
fix: incorrect return type annotation for Message.to_dict

### DIFF
--- a/proto/message.py
+++ b/proto/message.py
@@ -16,7 +16,7 @@ import collections
 import collections.abc
 import copy
 import re
-from typing import List, Optional, Type
+from typing import Any, Dict, List, Optional, Type
 import warnings
 
 import google.protobuf
@@ -558,7 +558,7 @@ class MessageMeta(type):
         including_default_value_fields=None,
         float_precision=None,
         always_print_fields_with_no_presence=None,
-    ) -> "Message":
+    ) -> Dict[str, Any]:
         """Given a message instance, return its representation as a python dict.
 
         Args:


### PR DESCRIPTION
The `proto.Message.to_dict` function returns a `dict[str, Any]`, but its return type annotation is incorrectly set to `Message`.

The `proto.Message.to_dict` function returns the result of calling [`google.protobuf.json_format.MessageToDict()`](https://github.com/protocolbuffers/protobuf/blob/c58621b6ff2e6145ffb14c7e5a7af7648dfc0535/python/google/protobuf/json_format.py#L125-L162), which returns `dict[str, Any]` as specified in the [protobuf typeshed stubs](https://github.com/python/typeshed/blob/main/stubs/protobuf/google/protobuf/json_format.pyi#L23-L30).

Additionally, runtime introspection shows that the function returns a `dict`.

Fixes #489 