### PR TITLE
fix: construct messages with nested duration in protobuf 5.28+

### DIFF
--- a/proto/marshal/rules/message.py
+++ b/proto/marshal/rules/message.py
@@ -41,8 +41,8 @@ class MessageRule:
                 # - an int64/string issue.
                 # - a missing key issue in case a key only exists with a `_` suffix.
                 #   See related issue: https://github.com/googleapis/python-api-core/issues/227.
-                # - a missing key issue due to nested struct. See: b/321905145.
-                # - a missing key issue due to nested duration. See: b/383651746.
+                # - a missing key issue due to nested struct. See: https://github.com/googleapis/proto-plus-python/issues/424.
+                # - a missing key issue due to nested duration. See: https://github.com/googleapis/google-cloud-python/issues/13350.
                 return self._wrapper(value)._pb
         return value
 

--- a/proto/marshal/rules/message.py
+++ b/proto/marshal/rules/message.py
@@ -34,14 +34,15 @@ class MessageRule:
             try:
                 # Try the fast path first.
                 return self._descriptor(**value)
-            except (TypeError, ValueError) as ex:
-                # If we have a TypeError or Valueerror,
+            except (TypeError, ValueError, AttributeError) as ex:
+                # If we have a TypeError, Valueerror or AttributeError,
                 # try the slow path in case the error
                 # was:
                 # - an int64/string issue.
                 # - a missing key issue in case a key only exists with a `_` suffix.
                 #   See related issue: https://github.com/googleapis/python-api-core/issues/227.
                 # - a missing key issue due to nested struct. See: b/321905145.
+                # - a missing key issue due to nested duration. See: b/383651746.
                 return self._wrapper(value)._pb
         return value
 

--- a/proto/marshal/rules/message.py
+++ b/proto/marshal/rules/message.py
@@ -35,7 +35,7 @@ class MessageRule:
                 # Try the fast path first.
                 return self._descriptor(**value)
             except (TypeError, ValueError, AttributeError) as ex:
-                # If we have a TypeError, Valueerror or AttributeError,
+                # If we have a TypeError, ValueError or AttributeError,
                 # try the slow path in case the error
                 # was:
                 # - an int64/string issue.

--- a/tests/test_marshal_types_dates.py
+++ b/tests/test_marshal_types_dates.py
@@ -241,6 +241,26 @@ def test_duration_write_string():
     assert Foo.pb(foo).ttl.seconds == 120
 
 
+def test_duration_write_string_nested():
+    class Foo(proto.Message):
+        another_field: duration_pb2.Duration = proto.Field(
+            proto.MESSAGE,
+            number=1,
+            message=duration_pb2.Duration,
+        )
+
+    Foo(another_field="300s")
+
+    class Bar(proto.Message):
+        some_field = proto.Field(proto.MESSAGE, number=1, message=Foo)
+
+    bar = Bar({"some_field": {"another_field": "300s"}})
+    assert isinstance(bar.some_field.another_field, timedelta)
+    assert isinstance(Bar.pb(bar).some_field.another_field, duration_pb2.Duration)
+    assert bar.some_field.another_field.seconds == 300
+    assert Bar.pb(bar).some_field.another_field.seconds == 300
+
+
 def test_duration_del():
     class Foo(proto.Message):
         ttl = proto.Field(

--- a/tests/test_marshal_types_dates.py
+++ b/tests/test_marshal_types_dates.py
@@ -243,22 +243,22 @@ def test_duration_write_string():
 
 def test_duration_write_string_nested():
     class Foo(proto.Message):
-        another_field: duration_pb2.Duration = proto.Field(
+        foo_field: duration_pb2.Duration = proto.Field(
             proto.MESSAGE,
             number=1,
             message=duration_pb2.Duration,
         )
 
-    Foo(another_field="300s")
+    Foo(foo_field="300s")
 
     class Bar(proto.Message):
-        some_field = proto.Field(proto.MESSAGE, number=1, message=Foo)
+        bar_field = proto.Field(proto.MESSAGE, number=1, message=Foo)
 
-    bar = Bar({"some_field": {"another_field": "300s"}})
-    assert isinstance(bar.some_field.another_field, timedelta)
-    assert isinstance(Bar.pb(bar).some_field.another_field, duration_pb2.Duration)
-    assert bar.some_field.another_field.seconds == 300
-    assert Bar.pb(bar).some_field.another_field.seconds == 300
+    bar = Bar({"bar_field": {"foo_field": "300s"}})
+    assert isinstance(bar.bar_field.foo_field, timedelta)
+    assert isinstance(Bar.pb(bar).bar_field.foo_field, duration_pb2.Duration)
+    assert bar.bar_field.foo_field.seconds == 300
+    assert Bar.pb(bar).bar_field.foo_field.seconds == 300
 
 
 def test_duration_del():


### PR DESCRIPTION
This fix is similar to https://github.com/googleapis/proto-plus-python/pull/479 where message construction fails when a specific type, in this case `google.protobuf.duration_pb2.Duration`, is nested.

Fixes https://github.com/googleapis/proto-plus-python/issues/518
Fixes https://github.com/googleapis/google-cloud-python/issues/13350