### PR TITLE
docs: Update docs link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,11 +18,9 @@ Documentation
 
 `Documentation`_ is available on Read the Docs.
 
-.. _documentation: https://proto-plus-python.readthedocs.io/en/latest/
+.. _documentation: https://googleapis.dev/python/proto-plus/latest/
 
 .. |pypi| image:: https://img.shields.io/pypi/v/proto-plus.svg
    :target: https://pypi.org/project/proto-plus
 .. |release level| image:: https://img.shields.io/badge/release%20level-ga-gold.svg?style&#x3D;flat
   :target: https://cloud.google.com/terms/launch-stages
-.. |docs| image:: https://readthedocs.org/projects/proto-plus-python/badge/?version=latest
-  :target: https://proto-plus-python.readthedocs.io/en/latest/


### PR DESCRIPTION
Documentation lives at https://googleapis.dev/python/proto-plus/latest however the link in the README points to https://proto-plus-python.readthedocs.io/en/latest/ which is obsolete. 