### PR TITLE
chore: remove broken link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Proto Plus for Python
 =====================
 
-|pypi| |release level| |docs|
+|pypi| |release level|
 
     Beautiful, Pythonic protocol buffers.
 


### PR DESCRIPTION
Remove broken link `docs` which was removed in https://github.com/googleapis/proto-plus-python/pull/524