### PR TITLE
fix(deps): allow protobuf 6.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
   "Topic :: Software Development :: Code Generators",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = ["protobuf >=3.19.0, < 6.0.0dev"]
+dependencies = ["protobuf >=3.19.0, < 7.0.0dev"]
 dynamic = ["version"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
   "Topic :: Software Development :: Code Generators",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = ["protobuf >=3.19.0, < 7.0.0dev"]
+dependencies = ["protobuf >=3.19.0, < 7.0.0"]
 dynamic = ["version"]
 
 [project.urls]


### PR DESCRIPTION
See https://pypi.org/project/protobuf/6.30.0/. Also see https://github.com/googleapis/google-cloud-python/issues/13585 for the removal of `dev`