### PR TITLE
fix: avoid hardcoding single python version in nox

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -131,7 +131,7 @@ def prerelease_deps(session, implementation):
     )
 
 
-@nox.session(python="3.10")
+@nox.session
 def docs(session):
     """Build the docs."""
 
@@ -164,7 +164,7 @@ def docs(session):
     )
 
 
-@nox.session(python="3.10")
+@nox.session
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
 


### PR DESCRIPTION
Remove hardcoded python version in a nox session if it runs against a single Python interpreter to avoid manually updating it every time when the interpreter is updated upstream in a github workflow.