### PR TITLE
tests: filter float_precision deprecation warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,6 @@ filterwarnings =
     ignore:.*custom tp_new.*in Python 3.14:DeprecationWarning
     # Remove once deprecated field `including_default_value_fields` is removed
     ignore:.*The argument `including_default_value_fields` has been removed.*:DeprecationWarning
+    # Remove once deprecated field `float_precision` is removed
+    # See https://github.com/googleapis/proto-plus-python/issues/547
+    ignore:float_precision option is deprecated for json_format:UserWarning


### PR DESCRIPTION
Without this PR, tests fail because warnings are treated as errors. See https://github.com/googleapis/google-cloud-python/issues/15099 for follow up work related to the warning.

```
________________________________________________________________________________________________________________________ test_serialize_to_dict_float_precision __________________________________________________________________________________________________________________________

    def test_serialize_to_dict_float_precision():
        class Squid(proto.Message):
            mass_kg = proto.Field(proto.FLOAT, number=1)
    
        s = Squid(mass_kg=3.14159265)
    
>       s_dict = Squid.to_dict(s, float_precision=3)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

tests/test_message.py:336: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
proto/message.py:610: in to_dict
    return MessageToDict(
.nox/unit-3-13-implementation-upb/lib/python3.13/site-packages/google/protobuf/json_format.py:158: in MessageToDict
    printer = _Printer(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <google.protobuf.json_format._Printer object at 0x7fb6d1f15940>, preserving_proto_field_name = True, use_integers_for_enums = True, descriptor_pool = None, float_precision = 3, always_print_fields_with_no_presence = True

    def __init__(
        self,
        preserving_proto_field_name=False,
        use_integers_for_enums=False,
        descriptor_pool=None,
        float_precision=None,
        always_print_fields_with_no_presence=False,
    ):
      self.always_print_fields_with_no_presence = (
          always_print_fields_with_no_presence
      )
      self.preserving_proto_field_name = preserving_proto_field_name
      self.use_integers_for_enums = use_integers_for_enums
      self.descriptor_pool = descriptor_pool
      if float_precision:
>       warnings.warn(
            'float_precision option is deprecated for json_format. '
            'This will turn into error in 7.34.0, please remove it '
            'before that.'
        )
E       UserWarning: float_precision option is deprecated for json_format. This will turn into error in 7.34.0, please remove it before that.

.nox/unit-3-13-implementation-upb/lib/python3.13/site-packages/google/protobuf/json_format.py:195: UserWarning
```