### PR TITLE
fix: remove float_precision for protobuf 7

### DIFF
--- a/proto/message.py
+++ b/proto/message.py
@@ -946,11 +946,12 @@ def _message_to_map(
         # float_precision removed in protobuf 7
         if _PROTOBUF_MAJOR_VERSION in ("3", "4", "5", "6"):
             kwargs["float_precision"] = float_precision
-            warning_msg = "`float_precision` will be removed in Protobuf 7.x."
-
         else:  # pragma: NO COVER
-            warning_msg = "`float_precision` was removed in Protobuf 7.x+, and will be ignored."
-        warnings.warn(warning_msg, DeprecationWarning, stacklevel=3)
+            warnings.warn(
+                "`float_precision` was removed from Protobuf 7.x, and will be ignored",
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
     return map_fn(cls.pb(instance), **kwargs)
 

--- a/proto/message.py
+++ b/proto/message.py
@@ -457,6 +457,46 @@ class MessageMeta(type):
             or including_default_value_fields
         )
 
+    @staticmethod
+    def _to_map(
+        cls,
+        map_fn,
+        instance,
+        *,
+        including_default_value_fields=None,
+        float_precision=None,
+        always_print_fields_with_no_presence=None,
+        **kwargs,
+    ):
+        """
+        Helper for logic for to_dict and to_json
+        """
+        print_fields = cls._normalize_print_fields_without_presence(
+            always_print_fields_with_no_presence, including_default_value_fields
+        )
+
+        # The `including_default_value_fields` argument was removed from protobuf 5.x
+        # and replaced with `always_print_fields_with_no_presence` which very similar but has
+        # handles optional fields consistently by not affecting them.
+        # The old flag accidentally had inconsistent behavior between proto2
+        # optional and proto3 optional fields.
+        if PROTOBUF_VERSION[0] in ("3", "4"):
+            kwargs["including_default_value_fields"] = print_fields
+        else:
+            kwargs["always_print_fields_with_no_presence"] = print_fields
+
+        if float_precision:
+            # float_precision removed in protobuf 7
+            if int(PROTOBUF_VERSION[0]) < 7:
+                kwargs["float_precision"] = float_precision
+            else:
+                warnings.warn(
+                    "The argument `float_precision` has been removed from Protobuf 7.x.",
+                    DeprecationWarning,
+                )
+
+        return map_fn(cls.pb(instance), **kwargs)
+
     def to_json(
         cls,
         instance,
@@ -491,7 +531,7 @@ class MessageMeta(type):
                 An indent level of 0 or negative will only insert newlines.
                 Pass None for the most compact representation without newlines.
             float_precision (Optional(int)): If set, use this to specify float field valid digits.
-                Default is None.
+                Default is None. [DEPRECATED] float_precision was removed in Protobuf 7.x.
             always_print_fields_with_no_presence (Optional(bool)): If True, fields without
                 presence (implicit presence scalars, repeated fields, and map fields) will
                 always be serialized. Any field that supports presence is not affected by
@@ -501,36 +541,7 @@ class MessageMeta(type):
         Returns:
             str: The json string representation of the protocol buffer.
         """
-
-        print_fields = cls._normalize_print_fields_without_presence(
-            always_print_fields_with_no_presence, including_default_value_fields
-        )
-
-        if PROTOBUF_VERSION[0] in ("3", "4"):
-            return MessageToJson(
-                cls.pb(instance),
-                use_integers_for_enums=use_integers_for_enums,
-                including_default_value_fields=print_fields,
-                preserving_proto_field_name=preserving_proto_field_name,
-                sort_keys=sort_keys,
-                indent=indent,
-                float_precision=float_precision,
-            )
-        else:
-            # The `including_default_value_fields` argument was removed from protobuf 5.x
-            # and replaced with `always_print_fields_with_no_presence` which very similar but has
-            # handles optional fields consistently by not affecting them.
-            # The old flag accidentally had inconsistent behavior between proto2
-            # optional and proto3 optional fields.
-            return MessageToJson(
-                cls.pb(instance),
-                use_integers_for_enums=use_integers_for_enums,
-                always_print_fields_with_no_presence=print_fields,
-                preserving_proto_field_name=preserving_proto_field_name,
-                sort_keys=sort_keys,
-                indent=indent,
-                float_precision=float_precision,
-            )
+        return cls._to_map(map_fn=MessageToJson, **locals())
 
     def from_json(cls, payload, *, ignore_unknown_fields=False) -> "Message":
         """Given a json string representing an instance,
@@ -576,9 +587,7 @@ class MessageMeta(type):
                 This value must match `always_print_fields_with_no_presence`,
                 if both arguments are explicitly set.
             float_precision (Optional(int)): If set, use this to specify float field valid digits.
-                Default is None.
-                [DEPRECATED] float_precision was removed in Protobuf 7.x, and will be ignored
-                in those versions
+                Default is None. [DEPRECATED] float_precision was removed in Protobuf 7.x.
             always_print_fields_with_no_presence (Optional(bool)): If True, fields without
                 presence (implicit presence scalars, repeated fields, and map fields) will
                 always be serialized. Any field that supports presence is not affected by
@@ -590,37 +599,7 @@ class MessageMeta(type):
                   Messages and map fields are represented as dicts,
                   repeated fields are represented as lists.
         """
-
-        print_fields = cls._normalize_print_fields_without_presence(
-            always_print_fields_with_no_presence, including_default_value_fields
-        )
-        kwargs = {
-            "preserving_proto_field_name":preserving_proto_field_name,
-            "use_integers_for_enums":use_integers_for_enums,
-            "float_precision": float_precision,
-        }
-
-        # The `including_default_value_fields` argument was removed from protobuf 5.x
-        # and replaced with `always_print_fields_with_no_presence` which very similar but has
-        # handles optional fields consistently by not affecting them.
-        # The old flag accidentally had inconsistent behavior between proto2
-        # optional and proto3 optional fields.
-        if PROTOBUF_VERSION[0] in ("3", "4"):
-            kwargs["including_default_value_fields"] = print_fields
-            del kwargs[always_print_fields_with_no_presence]
-        else:
-            kwargs["always_print_fields_with_no_presence"] = print_fields
-            del kwargs["including_default_value_fields]"
-
-        # float_precision removed in protobuf 7
-        if int(PROTOBUF_VERSION[0]) > 7 and float_precision is not None:
-            warnings.warn(
-                "The argument `float_precision` has been removed from Protobuf 7.x.",
-                DeprecationWarning,
-            )
-            del kwargs["float_precision"]
-
-        return MessageToDict(cls.pb(instance), **kwargs)
+        return cls._to_map(map_fn=MessageToDict, **locals())
 
     def copy_from(cls, instance, other):
         """Equivalent for protobuf.Message.CopyFrom

--- a/proto/message.py
+++ b/proto/message.py
@@ -36,6 +36,10 @@ from proto.utils import has_upb
 
 PROTOBUF_VERSION = google.protobuf.__version__
 
+# extract the major version code
+_separator_idx = PROTOBUF_VERSION.find('.')
+_PROTOBUF_MAJOR_VERSION = PROTOBUF_VERSION[:_separator_idx] if _separator_idx != -1 else PROTOBUF_VERSION
+
 _upb = has_upb()  # Important to cache result here.
 
 
@@ -383,7 +387,7 @@ class MessageMeta(type):
             including_default_value_fields (Optional(bool)): The value of `including_default_value_fields` set by the user.
         """
         if (
-            PROTOBUF_VERSION[0] not in ("3", "4")
+            _PROTOBUF_MAJOR_VERSION not in ("3", "4")
             and including_default_value_fields is not None
         ):
             warnings.warn(
@@ -918,30 +922,30 @@ def _message_to_map(
     instance,
     *,
     including_default_value_fields=None,
-    float_precision=None,
     always_print_fields_with_no_presence=None,
+    float_precision=None,
     **kwargs,
 ):
     """
     Helper for logic for Message.to_dict and Message.to_json
     """
-    print_fields = cls._normalize_print_fields_without_presence(
-        always_print_fields_with_no_presence, including_default_value_fields
-    )
 
     # The `including_default_value_fields` argument was removed from protobuf 5.x
     # and replaced with `always_print_fields_with_no_presence` which very similar but has
     # handles optional fields consistently by not affecting them.
     # The old flag accidentally had inconsistent behavior between proto2
     # optional and proto3 optional fields.
-    if PROTOBUF_VERSION[0] in ("3", "4"):
+    print_fields = cls._normalize_print_fields_without_presence(
+        always_print_fields_with_no_presence, including_default_value_fields
+    )
+    if _PROTOBUF_MAJOR_VERSION in ("3", "4"):
         kwargs["including_default_value_fields"] = print_fields
     else:
         kwargs["always_print_fields_with_no_presence"] = print_fields
 
     if float_precision:
         # float_precision removed in protobuf 7
-        if int(PROTOBUF_VERSION[0]) < 7:
+        if _PROTOBUF_MAJOR_VERSION in ("3", "4", "5", "6"):
             kwargs["float_precision"] = float_precision
         else:
             warnings.warn(

--- a/proto/message.py
+++ b/proto/message.py
@@ -607,15 +607,17 @@ class MessageMeta(type):
         # optional and proto3 optional fields.
         if PROTOBUF_VERSION[0] in ("3", "4"):
             kwargs["including_default_value_fields"] = print_fields
+            del kwargs[always_print_fields_with_no_presence]
         else:
+            kwargs["always_print_fields_with_no_presence"] = print_fields
+            del kwargs["including_default_value_fields]"
+
+        # float_precision removed in protobuf 7
+        if int(PROTOBUF_VERSION[0]) > 7 and float_precision is not None:
             warnings.warn(
                 "The argument `float_precision` has been removed from Protobuf 7.x.",
                 DeprecationWarning,
             )
-            kwargs["use_integers_for_enums"] = print_fields
-
-        # float_precision removed in protobuf 7
-        if int(PROTOBUF_VERSION[0]) > 7 and float_precision is not None:
             del kwargs["float_precision"]
 
         return MessageToDict(cls.pb(instance), **kwargs)

--- a/proto/message.py
+++ b/proto/message.py
@@ -951,6 +951,7 @@ def _message_to_map(
             warnings.warn(
                 "The argument `float_precision` has been removed from Protobuf 7.x.",
                 DeprecationWarning,
+                stacklevel=3,
             )
 
     return map_fn(cls.pb(instance), **kwargs)

--- a/proto/message.py
+++ b/proto/message.py
@@ -949,7 +949,7 @@ def _message_to_map(
         # float_precision removed in protobuf 7
         if _PROTOBUF_MAJOR_VERSION in ("3", "4", "5", "6"):
             kwargs["float_precision"] = float_precision
-        else:
+        else:  # pragma: NO COVER
             warnings.warn(
                 "The argument `float_precision` has been removed from Protobuf 7.x.",
                 DeprecationWarning,

--- a/proto/message.py
+++ b/proto/message.py
@@ -37,10 +37,7 @@ from proto.utils import has_upb
 PROTOBUF_VERSION = google.protobuf.__version__
 
 # extract the major version code
-_separator_idx = PROTOBUF_VERSION.find(".")
-_PROTOBUF_MAJOR_VERSION = (
-    PROTOBUF_VERSION[:_separator_idx] if _separator_idx != -1 else PROTOBUF_VERSION
-)
+_PROTOBUF_MAJOR_VERSION = PROTOBUF_VERSION.partition(".")[0]
 
 _upb = has_upb()  # Important to cache result here.
 

--- a/proto/message.py
+++ b/proto/message.py
@@ -946,12 +946,11 @@ def _message_to_map(
         # float_precision removed in protobuf 7
         if _PROTOBUF_MAJOR_VERSION in ("3", "4", "5", "6"):
             kwargs["float_precision"] = float_precision
+            warning_msg = "`float_precision` will be removed in Protobuf 7.x."
+
         else:  # pragma: NO COVER
-            warnings.warn(
-                "The argument `float_precision` has been removed from Protobuf 7.x.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
+            warning_msg = "`float_precision` was removed in Protobuf 7.x+, and will be ignored."
+        warnings.warn(warning_msg, DeprecationWarning, stacklevel=3)
 
     return map_fn(cls.pb(instance), **kwargs)
 

--- a/proto/message.py
+++ b/proto/message.py
@@ -37,8 +37,10 @@ from proto.utils import has_upb
 PROTOBUF_VERSION = google.protobuf.__version__
 
 # extract the major version code
-_separator_idx = PROTOBUF_VERSION.find('.')
-_PROTOBUF_MAJOR_VERSION = PROTOBUF_VERSION[:_separator_idx] if _separator_idx != -1 else PROTOBUF_VERSION
+_separator_idx = PROTOBUF_VERSION.find(".")
+_PROTOBUF_MAJOR_VERSION = (
+    PROTOBUF_VERSION[:_separator_idx] if _separator_idx != -1 else PROTOBUF_VERSION
+)
 
 _upb = has_upb()  # Important to cache result here.
 

--- a/proto/message.py
+++ b/proto/message.py
@@ -930,10 +930,10 @@ def _message_to_map(
     """
 
     # The `including_default_value_fields` argument was removed from protobuf 5.x
-    # and replaced with `always_print_fields_with_no_presence` which very similar but has
+    # and replaced with `always_print_fields_with_no_presence` which is similar but
     # handles optional fields consistently by not affecting them.
-    # The old flag accidentally had inconsistent behavior between proto2
-    # optional and proto3 optional fields.
+    # The old flag accidentally had inconsistent behavior between optional fields
+    # in proto2 and proto3.
     print_fields = cls._normalize_print_fields_without_presence(
         always_print_fields_with_no_presence, including_default_value_fields
     )
@@ -953,7 +953,7 @@ def _message_to_map(
                 "`float_precision` was removed in Protobuf 7.x+, and will be ignored."
             )
         warnings.warn(warning_msg, DeprecationWarning, stacklevel=3)
-    # supress similar float_precision warning from protobuf library
+    # suppress similar float_precision warning from protobuf library.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=UserWarning)
         return map_fn(cls.pb(instance), **kwargs)

--- a/proto/message.py
+++ b/proto/message.py
@@ -949,11 +949,13 @@ def _message_to_map(
             warning_msg = "`float_precision` will be removed in Protobuf 7.x."
 
         else:  # pragma: NO COVER
-            warning_msg = "`float_precision` was removed in Protobuf 7.x+, and will be ignored."
+            warning_msg = (
+                "`float_precision` was removed in Protobuf 7.x+, and will be ignored."
+            )
         warnings.warn(warning_msg, DeprecationWarning, stacklevel=3)
     # supress similar float_precision warning from protobuf library
     with warnings.catch_warnings():
-        warnings.simplefilter('ignore', category=UserWarning)
+        warnings.simplefilter("ignore", category=UserWarning)
         return map_fn(cls.pb(instance), **kwargs)
 
 

--- a/proto/message.py
+++ b/proto/message.py
@@ -955,7 +955,7 @@ def _message_to_map(
         warnings.warn(warning_msg, DeprecationWarning, stacklevel=3)
     # suppress similar float_precision warning from protobuf library.
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", message=".*float_precision.*")
+        warnings.filterwarnings("ignore", message=".*float_precision.*")
         return map_fn(cls.pb(instance), **kwargs)
 
 

--- a/proto/message.py
+++ b/proto/message.py
@@ -946,14 +946,15 @@ def _message_to_map(
         # float_precision removed in protobuf 7
         if _PROTOBUF_MAJOR_VERSION in ("3", "4", "5", "6"):
             kwargs["float_precision"] = float_precision
-        else:  # pragma: NO COVER
-            warnings.warn(
-                "`float_precision` was removed from Protobuf 7.x, and will be ignored",
-                DeprecationWarning,
-                stacklevel=3,
-            )
+            warning_msg = "`float_precision` will be removed in Protobuf 7.x."
 
-    return map_fn(cls.pb(instance), **kwargs)
+        else:  # pragma: NO COVER
+            warning_msg = "`float_precision` was removed in Protobuf 7.x+, and will be ignored."
+        warnings.warn(warning_msg, DeprecationWarning, stacklevel=3)
+    # supress similar float_precision warning from protobuf library
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=UserWarning)
+        return map_fn(cls.pb(instance), **kwargs)
 
 
 __all__ = ("Message",)

--- a/proto/message.py
+++ b/proto/message.py
@@ -955,7 +955,7 @@ def _message_to_map(
         warnings.warn(warning_msg, DeprecationWarning, stacklevel=3)
     # suppress similar float_precision warning from protobuf library.
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=UserWarning)
+        warnings.simplefilter("ignore", message=".*float_precision.*")
         return map_fn(cls.pb(instance), **kwargs)
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,4 +8,3 @@ filterwarnings =
     ignore:.*The argument `including_default_value_fields` has been removed.*:DeprecationWarning
     # Remove once deprecated field `float_precision` is removed
     # See https://github.com/googleapis/proto-plus-python/issues/547
-    ignore:float_precision option is deprecated for json_format:UserWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,5 +6,3 @@ filterwarnings =
     ignore:.*custom tp_new.*in Python 3.14:DeprecationWarning
     # Remove once deprecated field `including_default_value_fields` is removed
     ignore:.*The argument `including_default_value_fields` has been removed.*:DeprecationWarning
-    # Remove once deprecated field `float_precision` is removed
-    # See https://github.com/googleapis/proto-plus-python/issues/547

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -253,7 +253,10 @@ def test_json_sort_keys():
     assert re.search(r"massKg.*name", j)
 
 
-# TODO: https://github.com/googleapis/proto-plus-python/issues/390
+pytest.skipif(
+    int(proto.message._PROTOBUF_MAJOR_VERSION) >= 7,
+    "float_precision removed in protobuf 7.x"
+)
 def test_json_float_precision():
     class Squid(proto.Message):
         name = proto.Field(proto.STRING, number=1)
@@ -263,3 +266,21 @@ def test_json_float_precision():
     j = Squid.to_json(s, float_precision=3, indent=None)
 
     assert j == '{"name": "Steve", "massKg": 3.14}'
+
+pytest.skipif(
+    int(proto.message._PROTOBUF_MAJOR_VERSION) < 7,
+    "unsupported protobuf version for test"
+)
+def test_json_float_precision_7_plus():
+    class Squid(proto.Message):
+        name = proto.Field(proto.STRING, number=1)
+        mass_kg = proto.Field(proto.FLOAT, number=2)
+
+    s = Squid(name="Steve", mass_kg=3.14159265)
+    with pytest.warns(DeprecationWarning) as warnings:
+        j = Squid.to_json(s, float_precision=3, indent=None)
+
+    assert j == '{"name": "Steve", "massKg": 3.14159265}'
+
+    assert len(warnings) == 1
+    assert "`float_precision` has been removed" in warnings[0].message.args[0]

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -253,34 +253,33 @@ def test_json_sort_keys():
     assert re.search(r"massKg.*name", j)
 
 
-pytest.skipif(
-    int(proto.message._PROTOBUF_MAJOR_VERSION) >= 7,
-    "float_precision removed in protobuf 7.x"
-)
 def test_json_float_precision():
+    if int(proto.message._PROTOBUF_MAJOR_VERSION) >= 7:
+        pytest.skip("float_precision was removed in protobuf 7.x")
+
     class Squid(proto.Message):
         name = proto.Field(proto.STRING, number=1)
         mass_kg = proto.Field(proto.FLOAT, number=2)
 
-    s = Squid(name="Steve", mass_kg=3.14159265)
+    s = Squid(name="Steve", mass_kg=3.141592)
     j = Squid.to_json(s, float_precision=3, indent=None)
 
     assert j == '{"name": "Steve", "massKg": 3.14}'
 
-pytest.skipif(
-    int(proto.message._PROTOBUF_MAJOR_VERSION) < 7,
-    "unsupported protobuf version for test"
-)
+
 def test_json_float_precision_7_plus():
+    if int(proto.message._PROTOBUF_MAJOR_VERSION) < 7:
+        pytest.skip("unsupported protobuf version for test")
+
     class Squid(proto.Message):
         name = proto.Field(proto.STRING, number=1)
         mass_kg = proto.Field(proto.FLOAT, number=2)
 
-    s = Squid(name="Steve", mass_kg=3.14159265)
+    s = Squid(name="Steve", mass_kg=3.141592)
     with pytest.warns(DeprecationWarning) as warnings:
         j = Squid.to_json(s, float_precision=3, indent=None)
 
-    assert j == '{"name": "Steve", "massKg": 3.14159265}'
+    assert j == '{"name": "Steve", "massKg": 3.141592}'
 
     assert len(warnings) == 1
     assert "`float_precision` has been removed" in warnings[0].message.args[0]

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -261,10 +261,13 @@ def test_json_float_precision():
         name = proto.Field(proto.STRING, number=1)
         mass_kg = proto.Field(proto.FLOAT, number=2)
 
-    s = Squid(name="Steve", mass_kg=3.141592)
-    j = Squid.to_json(s, float_precision=3, indent=None)
+    with pytest.warns(UserWarning) as warnings:
+        s = Squid(name="Steve", mass_kg=3.141592)
+        j = Squid.to_json(s, float_precision=3, indent=None)
 
-    assert j == '{"name": "Steve", "massKg": 3.14}'
+        assert j == '{"name": "Steve", "massKg": 3.14}'
+    assert len(warnings) == 1
+    assert "float_precision option is deprecated" in warnings[0].message.args[0]
 
 
 def test_json_float_precision_7_plus():
@@ -282,4 +285,4 @@ def test_json_float_precision_7_plus():
     assert j == '{"name": "Steve", "massKg": 3.141592}'
 
     assert len(warnings) == 1
-    assert "`float_precision` has been removed" in warnings[0].message.args[0]
+    assert "`float_precision` was removed" in warnings[0].message.args[0]

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -14,6 +14,8 @@
 
 import pytest
 import re
+import sys
+from contextlib import nullcontext
 
 import proto
 from google.protobuf.json_format import MessageToJson, Parse, ParseError
@@ -256,18 +258,22 @@ def test_json_sort_keys():
 def test_json_float_precision():
     if int(proto.message._PROTOBUF_MAJOR_VERSION) >= 7:
         pytest.skip("float_precision was removed in protobuf 7.x")
+    # expect a warning in protobuf > 3
+    expect_warning = proto.message._PROTOBUF_MAJOR_VERSION != "3"
+    warn_checker = pytest.warns(UserWarning) if expect_warning  else nullcontext()
 
     class Squid(proto.Message):
         name = proto.Field(proto.STRING, number=1)
         mass_kg = proto.Field(proto.FLOAT, number=2)
 
-    with pytest.warns(UserWarning) as warnings:
+    with warn_checker:
         s = Squid(name="Steve", mass_kg=3.141592)
         j = Squid.to_json(s, float_precision=3, indent=None)
 
         assert j == '{"name": "Steve", "massKg": 3.14}'
-    assert len(warnings) == 1
-    assert "float_precision option is deprecated" in warnings[0].message.args[0]
+    if expect_warning:
+        assert len(warn_checker) == 1
+        assert "float_precision option is deprecated" in warn_checker[0].message.args[0]
 
 
 def test_json_float_precision_7_plus():

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -253,9 +253,12 @@ def test_json_sort_keys():
     assert re.search(r"massKg.*name", j)
 
 
-def test_json_float_precision():
-    if int(proto.message._PROTOBUF_MAJOR_VERSION) >= 7:
-        pytest.skip("float_precision was removed in protobuf 7.x")
+@pytest.mark.parametrize("expect_proto_7_plus", [True, False])
+def test_json_float_precision(expect_proto_7_plus):
+    if ((expect_proto_7_plus and int(proto.message._PROTOBUF_MAJOR_VERSION) < 7)) or (
+        (not expect_proto_7_plus and int(proto.message._PROTOBUF_MAJOR_VERSION) >= 7)
+    ):
+        pytest.skip("installed proto version does not match test")
 
     class Squid(proto.Message):
         name = proto.Field(proto.STRING, number=1)
@@ -265,24 +268,12 @@ def test_json_float_precision():
         s = Squid(name="Steve", mass_kg=3.141592)
         j = Squid.to_json(s, float_precision=3, indent=None)
 
+    assert len(warnings) == 1
+
+    # for protobuf <7, expect truncated float
+    if expect_proto_7_plus:
+        assert j == '{"name": "Steve", "massKg": 3.141592}'
+        assert "`float_precision` was removed" in warnings[0].message.args[0]
+    else:
         assert j == '{"name": "Steve", "massKg": 3.14}'
-    assert len(warnings) == 1
-    assert "`float_precision` will be removed" in warnings[0].message.args[0]
-
-
-def test_json_float_precision_7_plus():
-    if int(proto.message._PROTOBUF_MAJOR_VERSION) < 7:
-        pytest.skip("unsupported protobuf version for test")
-
-    class Squid(proto.Message):
-        name = proto.Field(proto.STRING, number=1)
-        mass_kg = proto.Field(proto.FLOAT, number=2)
-
-    s = Squid(name="Steve", mass_kg=3.141592)
-    with pytest.warns(DeprecationWarning) as warnings:
-        j = Squid.to_json(s, float_precision=3, indent=None)
-
-    assert j == '{"name": "Steve", "massKg": 3.141592}'
-
-    assert len(warnings) == 1
-    assert "`float_precision` was removed" in warnings[0].message.args[0]
+        assert "`float_precision` will be removed" in warnings[0].message.args[0]

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -253,7 +253,9 @@ def test_json_sort_keys():
     assert re.search(r"massKg.*name", j)
 
 
-@pytest.mark.parametrize("expect_proto_7_plus", [True, False], ids=["proto >= 7", "proto <= 6"])
+@pytest.mark.parametrize(
+    "expect_proto_7_plus", [True, False], ids=["proto >= 7", "proto <= 6"]
+)
 def test_json_float_precision(expect_proto_7_plus):
     if ((expect_proto_7_plus and int(proto.message._PROTOBUF_MAJOR_VERSION) < 7)) or (
         (not expect_proto_7_plus and int(proto.message._PROTOBUF_MAJOR_VERSION) >= 7)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -14,8 +14,6 @@
 
 import pytest
 import re
-import sys
-from contextlib import nullcontext
 
 import proto
 from google.protobuf.json_format import MessageToJson, Parse, ParseError
@@ -258,22 +256,18 @@ def test_json_sort_keys():
 def test_json_float_precision():
     if int(proto.message._PROTOBUF_MAJOR_VERSION) >= 7:
         pytest.skip("float_precision was removed in protobuf 7.x")
-    # expect a warning in protobuf > 3
-    expect_warning = proto.message._PROTOBUF_MAJOR_VERSION != "3"
-    warn_checker = pytest.warns(UserWarning) if expect_warning  else nullcontext()
 
     class Squid(proto.Message):
         name = proto.Field(proto.STRING, number=1)
         mass_kg = proto.Field(proto.FLOAT, number=2)
 
-    with warn_checker:
+    with pytest.warns(DeprecationWarning) as warnings:
         s = Squid(name="Steve", mass_kg=3.141592)
         j = Squid.to_json(s, float_precision=3, indent=None)
 
         assert j == '{"name": "Steve", "massKg": 3.14}'
-    if expect_warning:
-        assert len(warn_checker) == 1
-        assert "float_precision option is deprecated" in warn_checker[0].message.args[0]
+    assert len(warnings) == 1
+    assert "`float_precision` will be removed" in warnings[0].message.args[0]
 
 
 def test_json_float_precision_7_plus():

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -253,7 +253,7 @@ def test_json_sort_keys():
     assert re.search(r"massKg.*name", j)
 
 
-@pytest.mark.parametrize("expect_proto_7_plus", [True, False])
+@pytest.mark.parametrize("expect_proto_7_plus", [True, False], ids=["proto >= 7", "proto <= 6"])
 def test_json_float_precision(expect_proto_7_plus):
     if ((expect_proto_7_plus and int(proto.message._PROTOBUF_MAJOR_VERSION) < 7)) or (
         (not expect_proto_7_plus and int(proto.message._PROTOBUF_MAJOR_VERSION) >= 7)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -335,8 +335,11 @@ def test_serialize_to_dict_float_precision():
 
     s = Squid(mass_kg=3.141592)
 
-    s_dict = Squid.to_dict(s, float_precision=3)
-    assert s_dict["mass_kg"] == 3.14
+    with pytest.warns(UserWarning) as warnings:
+        s_dict = Squid.to_dict(s, float_precision=3)
+        assert s_dict["mass_kg"] == 3.14
+    assert len(warnings) == 1
+    assert "float_precision option is deprecated" in warnings[0].message.args[0]
 
 
 def test_serialize_to_dict_float_precision_7_plus():
@@ -353,7 +356,7 @@ def test_serialize_to_dict_float_precision_7_plus():
         assert s_dict["mass_kg"] == pytest.approx(3.141592)
 
     assert len(warnings) == 1
-    assert "`float_precision` has been removed" in warnings[0].message.args[0]
+    assert "`float_precision` was removed" in warnings[0].message.args[0]
 
 
 def test_unknown_field_deserialize():

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -326,15 +326,34 @@ def test_serialize_to_dict():
         )
 
 
-# TODO: https://github.com/googleapis/proto-plus-python/issues/390
 def test_serialize_to_dict_float_precision():
+    if int(proto.message._PROTOBUF_MAJOR_VERSION) >= 7:
+        pytest.skip("float_precision was removed in protobuf 7.x")
+
     class Squid(proto.Message):
         mass_kg = proto.Field(proto.FLOAT, number=1)
 
-    s = Squid(mass_kg=3.14159265)
+    s = Squid(mass_kg=3.141592)
 
     s_dict = Squid.to_dict(s, float_precision=3)
     assert s_dict["mass_kg"] == 3.14
+
+
+def test_serialize_to_dict_float_precision_7_plus():
+    if int(proto.message._PROTOBUF_MAJOR_VERSION) < 7:
+        pytest.skip("unsupported protobuf version for test")
+
+    class Squid(proto.Message):
+        mass_kg = proto.Field(proto.FLOAT, number=1)
+
+    s = Squid(mass_kg=3.141592)
+
+    with pytest.warns(DeprecationWarning) as warnings:
+        s_dict = Squid.to_dict(s, float_precision=3)
+        assert s_dict["mass_kg"] == pytest.approx(3.141592)
+
+    assert len(warnings) == 1
+    assert "`float_precision` has been removed" in warnings[0].message.args[0]
 
 
 def test_unknown_field_deserialize():

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -14,6 +14,8 @@
 
 import itertools
 import pytest
+import sys
+from contextlib import nullcontext
 
 import proto
 
@@ -329,17 +331,21 @@ def test_serialize_to_dict():
 def test_serialize_to_dict_float_precision():
     if int(proto.message._PROTOBUF_MAJOR_VERSION) >= 7:
         pytest.skip("float_precision was removed in protobuf 7.x")
+    # expect a warning in protobuf > 3
+    expect_warning = proto.message._PROTOBUF_MAJOR_VERSION != "3"
+    warn_checker = pytest.warns(UserWarning) if expect_warning  else nullcontext()
 
     class Squid(proto.Message):
         mass_kg = proto.Field(proto.FLOAT, number=1)
 
     s = Squid(mass_kg=3.141592)
 
-    with pytest.warns(UserWarning) as warnings:
+    with warn_checker:
         s_dict = Squid.to_dict(s, float_precision=3)
         assert s_dict["mass_kg"] == 3.14
-    assert len(warnings) == 1
-    assert "float_precision option is deprecated" in warnings[0].message.args[0]
+    if expect_warning:
+        assert len(warn_checker) == 1
+        assert "float_precision option is deprecated" in warn_checker[0].message.args[0]
 
 
 def test_serialize_to_dict_float_precision_7_plus():

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -14,8 +14,6 @@
 
 import itertools
 import pytest
-import sys
-from contextlib import nullcontext
 
 import proto
 
@@ -331,21 +329,17 @@ def test_serialize_to_dict():
 def test_serialize_to_dict_float_precision():
     if int(proto.message._PROTOBUF_MAJOR_VERSION) >= 7:
         pytest.skip("float_precision was removed in protobuf 7.x")
-    # expect a warning in protobuf > 3
-    expect_warning = proto.message._PROTOBUF_MAJOR_VERSION != "3"
-    warn_checker = pytest.warns(UserWarning) if expect_warning  else nullcontext()
 
     class Squid(proto.Message):
         mass_kg = proto.Field(proto.FLOAT, number=1)
 
     s = Squid(mass_kg=3.141592)
 
-    with warn_checker:
+    with pytest.warns(DeprecationWarning) as warnings:
         s_dict = Squid.to_dict(s, float_precision=3)
         assert s_dict["mass_kg"] == 3.14
-    if expect_warning:
-        assert len(warn_checker) == 1
-        assert "float_precision option is deprecated" in warn_checker[0].message.args[0]
+    assert len(warnings) == 1
+    assert "`float_precision` will be removed" in warnings[0].message.args[0]
 
 
 def test_serialize_to_dict_float_precision_7_plus():

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -326,9 +326,12 @@ def test_serialize_to_dict():
         )
 
 
-def test_serialize_to_dict_float_precision():
-    if int(proto.message._PROTOBUF_MAJOR_VERSION) >= 7:
-        pytest.skip("float_precision was removed in protobuf 7.x")
+@pytest.mark.parametrize("expect_proto_7_plus", [True, False])
+def test_serialize_to_dict_float_precision(expect_proto_7_plus):
+    if ((expect_proto_7_plus and int(proto.message._PROTOBUF_MAJOR_VERSION) < 7)) or (
+        (not expect_proto_7_plus and int(proto.message._PROTOBUF_MAJOR_VERSION) >= 7)
+    ):
+        pytest.skip("installed proto version does not match test")
 
     class Squid(proto.Message):
         mass_kg = proto.Field(proto.FLOAT, number=1)
@@ -337,26 +340,15 @@ def test_serialize_to_dict_float_precision():
 
     with pytest.warns(DeprecationWarning) as warnings:
         s_dict = Squid.to_dict(s, float_precision=3)
-        assert s_dict["mass_kg"] == 3.14
     assert len(warnings) == 1
     assert "`float_precision` will be removed" in warnings[0].message.args[0]
-
-
-def test_serialize_to_dict_float_precision_7_plus():
-    if int(proto.message._PROTOBUF_MAJOR_VERSION) < 7:
-        pytest.skip("unsupported protobuf version for test")
-
-    class Squid(proto.Message):
-        mass_kg = proto.Field(proto.FLOAT, number=1)
-
-    s = Squid(mass_kg=3.141592)
-
-    with pytest.warns(DeprecationWarning) as warnings:
-        s_dict = Squid.to_dict(s, float_precision=3)
+    # for protobuf <7, expect truncated float
+    if expect_proto_7_plus:
         assert s_dict["mass_kg"] == pytest.approx(3.141592)
-
-    assert len(warnings) == 1
-    assert "`float_precision` was removed" in warnings[0].message.args[0]
+        assert "`float_precision` was removed" in warnings[0].message.args[0]
+    else:
+        assert s_dict["mass_kg"] == pytest.approx(3.14)
+        assert "`float_precision` will be removed" in warnings[0].message.args[0]
 
 
 def test_unknown_field_deserialize():

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -326,7 +326,7 @@ def test_serialize_to_dict():
         )
 
 
-@pytest.mark.parametrize("expect_proto_7_plus", [True, False])
+@pytest.mark.parametrize("expect_proto_7_plus", [True, False], ids=["proto >= 7", "proto <= 6"])
 def test_serialize_to_dict_float_precision(expect_proto_7_plus):
     if ((expect_proto_7_plus and int(proto.message._PROTOBUF_MAJOR_VERSION) < 7)) or (
         (not expect_proto_7_plus and int(proto.message._PROTOBUF_MAJOR_VERSION) >= 7)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -326,7 +326,9 @@ def test_serialize_to_dict():
         )
 
 
-@pytest.mark.parametrize("expect_proto_7_plus", [True, False], ids=["proto >= 7", "proto <= 6"])
+@pytest.mark.parametrize(
+    "expect_proto_7_plus", [True, False], ids=["proto >= 7", "proto <= 6"]
+)
 def test_serialize_to_dict_float_precision(expect_proto_7_plus):
     if ((expect_proto_7_plus and int(proto.message._PROTOBUF_MAJOR_VERSION) < 7)) or (
         (not expect_proto_7_plus and int(proto.message._PROTOBUF_MAJOR_VERSION) >= 7)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -341,7 +341,6 @@ def test_serialize_to_dict_float_precision(expect_proto_7_plus):
     with pytest.warns(DeprecationWarning) as warnings:
         s_dict = Squid.to_dict(s, float_precision=3)
     assert len(warnings) == 1
-    assert "`float_precision` will be removed" in warnings[0].message.args[0]
     # for protobuf <7, expect truncated float
     if expect_proto_7_plus:
         assert s_dict["mass_kg"] == pytest.approx(3.141592)


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-python/issues/15099

Protobuf 7 is removing the float_prevision argument. This PR ignores it when passed in 7.x+, and raises a DeprecationWarning

