### PR TITLE
chore: librarian release pull request: 20260130T125408Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:d7caef319a25d618e20ba798b103434700bfd80015f525802d87621ca2528c90
 libraries:
   - id: proto-plus
-    version: 1.27.0
+    version: 1.27.1
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/proto-plus/#history
 
+## [1.27.1](https://github.com/googleapis/proto-plus-python/compare/v1.27.0...v1.27.1) (2026-01-30)
+
+
+### Bug Fixes
+
+* remove float_precision for protobuf 7 (#559) ([390b9d571bb5e58879137d5ac7c4cea1978e0024](https://github.com/googleapis/proto-plus-python/commit/390b9d571bb5e58879137d5ac7c4cea1978e0024))
+
 ## [1.27.0](https://github.com/googleapis/proto-plus-python/compare/v1.26.1...v1.27.0) (2025-12-12)
 
 

--- a/proto/version.py
+++ b/proto/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "1.27.0"
+__version__ = "1.27.1"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.1
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:d7caef319a25d618e20ba798b103434700bfd80015f525802d87621ca2528c90
<details><summary>proto-plus: 1.27.1</summary>

## [1.27.1](https://github.com/googleapis/proto-plus-python/compare/v1.27.0...v1.27.1) (2026-01-30)

### Bug Fixes

* remove float_precision for protobuf 7 (#559) ([390b9d57](https://github.com/googleapis/proto-plus-python/commit/390b9d57))

</details>